### PR TITLE
fix(tx-builder): Wrong abi input breaks tx-builder

### DIFF
--- a/apps/tx-builder/src/lib/interfaceRepository.ts
+++ b/apps/tx-builder/src/lib/interfaceRepository.ts
@@ -34,11 +34,15 @@ class InterfaceRepository {
 
     const methods = parsedAbi
       .filter((e: any) => {
+        if (Object.keys(e).length === 0) {
+          return false
+        }
+
         if (['pure', 'view'].includes(e.stateMutability)) {
           return false
         }
 
-        if (e?.type.toLowerCase() === 'event') {
+        if (e?.type?.toLowerCase() === 'event') {
           return false
         }
 


### PR DESCRIPTION
## What it solves
Resolves #439 

## How this PR fixes it
We should check if the object representing ABI items have props