### PR TITLE
fix(drain-safe): Avoid showing no assets message before checking if the Safe has or no…

### DIFF
--- a/apps/drain-safe/src/components/App.tsx
+++ b/apps/drain-safe/src/components/App.tsx
@@ -141,6 +141,13 @@ const App = (): React.ReactElement => {
         <Logo />
         <Title size="md">Drain Account</Title>
       </Flex>
+
+      {error && (
+        <Text size="xl" color="error">
+          {error}
+        </Text>
+      )}
+
       {assets.length ? (
         <>
           <Balances
@@ -149,7 +156,6 @@ const App = (): React.ReactElement => {
             assets={assets}
             onSelectionChange={setSelectedTokens}
           />
-          {error && <Text size="lg">{error}</Text>}
           {isFinished && (
             <TimedComponent timeout={5000} onTimeout={() => setFinished(false)}>
               <Text size="lg">

--- a/apps/drain-safe/src/components/App.tsx
+++ b/apps/drain-safe/src/components/App.tsx
@@ -15,15 +15,17 @@ import CancelButton from './CancelButton'
 import AddressInput from './AddressInput'
 import useWeb3 from '../hooks/useWeb3'
 import TimedComponent from './TimedComponent'
+import AppLoader from './AppLoader'
 
 const App = (): React.ReactElement => {
   const { sdk, safe } = useSafeAppsSDK()
   const { web3 } = useWeb3()
   const {
     assets,
+    loaded,
+    error: balancesError,
     selectedTokens,
     setSelectedTokens,
-    error: balancesError,
   }: BalancesType = useBalances(safe.safeAddress, safe.chainId)
   const [submitting, setSubmitting] = useState(false)
   const [toAddress, setToAddress] = useState<string>('')
@@ -128,6 +130,10 @@ const App = (): React.ReactElement => {
 
     getChainInfo()
   }, [sdk])
+
+  if (!loaded) {
+    return <AppLoader />
+  }
 
   return (
     <FormContainer onSubmit={onSubmit} onReset={onCancel}>

--- a/apps/drain-safe/src/components/AppLoader.tsx
+++ b/apps/drain-safe/src/components/AppLoader.tsx
@@ -1,0 +1,19 @@
+import { Title, Loader } from '@gnosis.pm/safe-react-components'
+import { Grid } from '@material-ui/core'
+
+const AppLoader = (): React.ReactElement => {
+  return (
+    <Grid
+      container
+      direction="column"
+      justifyContent="center"
+      alignItems="center"
+      style={{ height: 'calc(100% - 100px)' }}
+    >
+      <Title size="md">Waiting for Safe...</Title>
+      <Loader size="md" />
+    </Grid>
+  )
+}
+
+export default AppLoader

--- a/apps/drain-safe/src/hooks/use-balances.ts
+++ b/apps/drain-safe/src/hooks/use-balances.ts
@@ -35,9 +35,10 @@ function useBalances(safeAddress: string, chainId: number): BalancesType {
 
       setAssets(assets)
       setSelectedTokens(assets.map((token: TokenBalance) => token.tokenInfo.address))
-      setLoaded(true)
     } catch (err) {
       setError(err as Error)
+    } finally {
+      setLoaded(true)
     }
   }, [safeAddress, chainId, sdk])
 

--- a/apps/drain-safe/src/hooks/use-balances.ts
+++ b/apps/drain-safe/src/hooks/use-balances.ts
@@ -4,8 +4,9 @@ import { TokenBalance } from '@gnosis.pm/safe-apps-sdk'
 import { NATIVE_TOKEN } from '../utils/sdk-helpers'
 
 export type BalancesType = {
-  error?: Error
   assets: TokenBalance[]
+  error?: Error
+  loaded: boolean
   selectedTokens: string[]
   setSelectedTokens: (tokens: string[]) => void
 }
@@ -19,6 +20,7 @@ function useBalances(safeAddress: string, chainId: number): BalancesType {
   const [assets, setAssets] = useState<TokenBalance[]>([])
   const [selectedTokens, setSelectedTokens] = useState<string[]>([])
   const [error, setError] = useState<Error>()
+  const [loaded, setLoaded] = useState(false)
 
   const loadBalances = useCallback(async () => {
     if (!safeAddress || !chainId) {
@@ -33,6 +35,7 @@ function useBalances(safeAddress: string, chainId: number): BalancesType {
 
       setAssets(assets)
       setSelectedTokens(assets.map((token: TokenBalance) => token.tokenInfo.address))
+      setLoaded(true)
     } catch (err) {
       setError(err as Error)
     }
@@ -42,7 +45,7 @@ function useBalances(safeAddress: string, chainId: number): BalancesType {
     loadBalances()
   }, [loadBalances])
 
-  return { error, assets, selectedTokens, setSelectedTokens }
+  return { assets, error, loaded, selectedTokens, setSelectedTokens }
 }
 
 export default useBalances

--- a/apps/drain-safe/src/index.tsx
+++ b/apps/drain-safe/src/index.tsx
@@ -1,24 +1,18 @@
 import React from 'react'
 import ReactDOM from 'react-dom'
 import { ThemeProvider } from 'styled-components'
-import { theme, Loader, Title } from '@gnosis.pm/safe-react-components'
+import { theme } from '@gnosis.pm/safe-react-components'
 import SafeProvider from '@gnosis.pm/safe-apps-react-sdk'
 
 import GlobalStyle from './GlobalStyle'
 import App from './components/App'
+import AppLoader from './components/AppLoader'
 
 ReactDOM.render(
   <React.StrictMode>
     <ThemeProvider theme={theme}>
       <GlobalStyle />
-      <SafeProvider
-        loader={
-          <>
-            <Title size="md">Waiting for Safe...</Title>
-            <Loader size="md" />
-          </>
-        }
-      >
+      <SafeProvider loader={<AppLoader />}>
         <App />
       </SafeProvider>
     </ThemeProvider>


### PR DESCRIPTION
## What it solves
Resolves #428 

## How this PR fixes it
By adding an intermediate loader before the assets finish loading
