### PR TITLE
fix(tx-builder): Fix Tenderly simulations not working after reorder (drag&drop)

### DIFF
--- a/apps/tx-builder/src/hooks/useSimulation.ts
+++ b/apps/tx-builder/src/hooks/useSimulation.ts
@@ -1,4 +1,3 @@
-import { BaseTransaction } from '@gnosis.pm/safe-apps-sdk'
 import { useCallback, useState, useMemo } from 'react'
 import { TenderlySimulation } from '../lib/simulation/types'
 import {
@@ -8,6 +7,7 @@ import {
   getSimulationLink,
 } from '../lib/simulation/simulation'
 import { useNetwork } from '../store/networkContext'
+import { useTransactions } from '../store'
 import { FETCH_STATUS } from '../utils'
 
 type UseSimulationReturn =
@@ -24,7 +24,8 @@ type UseSimulationReturn =
       simulationLink: string
     }
 
-const useSimulation = (transactions: BaseTransaction[]): UseSimulationReturn => {
+const useSimulation = (): UseSimulationReturn => {
+  const { transactions } = useTransactions()
   const [simulation, setSimulation] = useState<TenderlySimulation | undefined>()
   const [simulationRequestStatus, setSimulationRequestStatus] = useState<FETCH_STATUS>(
     FETCH_STATUS.NOT_ASKED,
@@ -48,7 +49,7 @@ const useSimulation = (transactions: BaseTransaction[]): UseSimulationReturn => 
         safeAddress: safe.safeAddress,
         executionOwner: safe.owners[0],
         safeNonce,
-        transactions,
+        transactions: transactions.map(t => t.raw),
         gasLimit: parseInt(blockGasLimit),
       })
 

--- a/apps/tx-builder/src/pages/ReviewAndConfirm.tsx
+++ b/apps/tx-builder/src/pages/ReviewAndConfirm.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useState } from 'react'
 import {
   Button,
   ButtonLink,
@@ -42,10 +42,9 @@ const ReviewAndConfirm = () => {
     reorderTransactions,
   } = useTransactions()
   const { downloadBatch, saveBatch } = useTransactionLibrary()
-  const rawTransactions = useMemo(() => transactions.map(t => t.raw), [transactions])
   const [showSimulation, setShowSimulation] = useState<boolean>(false)
   const { simulation, simulateTransaction, simulationRequestStatus, simulationLink } =
-    useSimulation(rawTransactions)
+    useSimulation()
   const navigate = useNavigate()
 
   const clickSimulate = () => {


### PR DESCRIPTION
## What it solves
Resolves #453 

## How this PR fixes it
We are using the useTransactions hook inside the useSimulation one for up to date information not depending on UI state changes

## How to test it
1) Add several transactions and simulate in the Review and confirm
2) After that reorder transactions and simulate again => New simulation should reflect the changes

