### PR TITLE
fix(tx-builder): simulation not available on some chains but the button is still there

### DIFF
--- a/apps/tx-builder/src/hooks/useSimulation.ts
+++ b/apps/tx-builder/src/hooks/useSimulation.ts
@@ -5,6 +5,7 @@ import {
   getSimulationPayload,
   getSimulation,
   getSimulationLink,
+  isSimulationSupported,
 } from '../lib/simulation/simulation'
 import { useNetwork } from '../store/networkContext'
 import { useTransactions } from '../store'
@@ -16,12 +17,14 @@ type UseSimulationReturn =
       simulation: undefined
       simulateTransaction: () => void
       simulationLink: string
+      simulationSupported: boolean
     }
   | {
       simulationRequestStatus: FETCH_STATUS.SUCCESS
       simulation: TenderlySimulation
       simulateTransaction: () => void
       simulationLink: string
+      simulationSupported: boolean
     }
 
 const useSimulation = (): UseSimulationReturn => {
@@ -35,6 +38,7 @@ const useSimulation = (): UseSimulationReturn => {
     [simulation],
   )
   const { safe, web3 } = useNetwork()
+  const simulationSupported = useMemo(() => isSimulationSupported(safe.chainId.toString()), [safe])
 
   const simulateTransaction = useCallback(async () => {
     if (!web3) return
@@ -67,6 +71,7 @@ const useSimulation = (): UseSimulationReturn => {
     simulationRequestStatus,
     simulation,
     simulationLink,
+    simulationSupported,
   } as UseSimulationReturn
 }
 

--- a/apps/tx-builder/src/lib/simulation/simulation.ts
+++ b/apps/tx-builder/src/lib/simulation/simulation.ts
@@ -14,6 +14,17 @@ const TENDERLY_SIMULATE_ENDPOINT_URL = process.env.REACT_APP_TENDERLY_SIMULATE_E
 const TENDERLY_PROJECT_NAME = process.env.REACT_APP_TENDERLY_PROJECT_NAME || ''
 const TENDERLY_ORG_NAME = process.env.REACT_APP_TENDERLY_ORG_NAME || ''
 
+const NON_SUPPORTED_CHAINS = [
+  // Energy web chain
+  '246',
+  // Volta
+  '73799',
+  // Aurora
+  '1313161554',
+]
+
+const isSimulationSupported = (chainId: string) => !NON_SUPPORTED_CHAINS.includes(chainId)
+
 const getSimulation = async (tx: TenderlySimulatePayload): Promise<TenderlySimulation> => {
   const response = await axios.post<TenderlySimulation>(TENDERLY_SIMULATE_ENDPOINT_URL, tx)
 
@@ -210,4 +221,10 @@ const getSimulationPayload = (tx: SimulationTxParams): TenderlySimulatePayload =
   }
 }
 
-export { getSimulationLink, getSimulation, getSimulationPayload, getBlockMaxGasLimit }
+export {
+  getSimulationLink,
+  getSimulation,
+  getSimulationPayload,
+  getBlockMaxGasLimit,
+  isSimulationSupported,
+}

--- a/apps/tx-builder/src/pages/ReviewAndConfirm.tsx
+++ b/apps/tx-builder/src/pages/ReviewAndConfirm.tsx
@@ -43,8 +43,13 @@ const ReviewAndConfirm = () => {
   } = useTransactions()
   const { downloadBatch, saveBatch } = useTransactionLibrary()
   const [showSimulation, setShowSimulation] = useState<boolean>(false)
-  const { simulation, simulateTransaction, simulationRequestStatus, simulationLink } =
-    useSimulation()
+  const {
+    simulation,
+    simulateTransaction,
+    simulationRequestStatus,
+    simulationLink,
+    simulationSupported,
+  } = useSimulation()
   const navigate = useNavigate()
 
   const clickSimulate = () => {
@@ -115,15 +120,17 @@ const ReviewAndConfirm = () => {
           </Button>
 
           {/* Simulate batch button */}
-          <Button
-            size="md"
-            type="button"
-            variant="contained"
-            color="secondary"
-            onClick={clickSimulate}
-          >
-            Simulate
-          </Button>
+          {simulationSupported && (
+            <Button
+              size="md"
+              type="button"
+              variant="contained"
+              color="secondary"
+              onClick={clickSimulate}
+            >
+              Simulate
+            </Button>
+          )}
         </ButtonsWrapper>
 
         {/* Simulation statuses */}
@@ -135,6 +142,12 @@ const ReviewAndConfirm = () => {
               color="inputFilled"
               onClick={closeSimulation}
             ></StyledButton>
+            {simulationRequestStatus === FETCH_STATUS.ERROR && (
+              <Text color="error" size="lg">
+                An unexpected error occurred during simulation.
+              </Text>
+            )}
+
             {simulationRequestStatus === FETCH_STATUS.LOADING && (
               <>
                 <Loader size="xs" />
@@ -247,8 +260,7 @@ const SimulationContainer = styled(Card)`
 
 const Wrapper = styled.main`
   && {
-    padding: 48px;
-    padding-top: 120px;
+    padding: 120px 48px 48px;
     max-width: 650px;
     margin: 0 auto;
   }


### PR DESCRIPTION
## What it solves
Resolves #432 

## How this PR fixes it
- Hides simulation button on chains where it is not supported
- Adds error feedback when the simulation request fails

## How to test it
1. Open tx builder on an unsupported chain. The simulation button shouldn't be there
2. To test the error feedback, you can run the tx-builder app locally, and there the request will fail

## Screenshots
![tx-builder-request-error](https://user-images.githubusercontent.com/16622558/175968784-4e52442c-7738-4bff-93dd-81d075189081.jpeg)

