### PR TITLE
feat: Record liveness tests in Cypress Dashboard

### DIFF
--- a/.github/workflows/safe-apps-check.yml
+++ b/.github/workflows/safe-apps-check.yml
@@ -32,12 +32,15 @@ jobs:
       - uses: cypress-io/github-action@v2
         with:
           browser: chrome
+          record: true
           spec: cypress/integration/safe-apps-check.spec.js
         env:
           CI: 'true'
+          CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
           CYPRESS_BASE_URL: ${{ github.event.inputs.baseUrl || 'http://gnosis-safe.io/app' }}
           CYPRESS_NETWORK_PREFIX: ${{ github.event.inputs.networkPrefix || 'eth' }}
           CYPRESS_TESTING_SAFE_ADDRESS: ${{ github.event.inputs.safeAddress || '0xc322cde085A4C6EFc865E77eDDdF39c31262Fc70' }}
           CYPRESS_CONFIG_SERVICE_BASE_URL: ${{ github.event.inputs.configServiceBaseUrl || 'https://safe-client.gnosis.io' }}
           SLACK_WEBHOOK_URL: ${{  secrets.SLACK_WEBHOOK_URL }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         continue-on-error: true


### PR DESCRIPTION
## What it solves

Allowing recording in Cypress Dashboard for liveness tests so we can take a look to the runs there
