### PR TITLE
feat(wallet-connect): Add permissions to manifest

### DIFF
--- a/apps/wallet-connect/public/manifest.json
+++ b/apps/wallet-connect/public/manifest.json
@@ -8,5 +8,6 @@
       "sizes": "any",
       "type": "image/svg+xml"
     }
-  ]
+  ],
+  "safe_apps_permissions": ["camera"]
 }


### PR DESCRIPTION
## What it solves
Resolves https://github.com/safe-global/safe-apps-sdk/issues/318

## How this PR fixes it
As part of the changes included for the new permissions system we need to update the wallet connect app in order to ask for `camera` permissions. In other case it will fail as we [removed the camera from the allow list](https://github.com/safe-global/safe-react/blob/1cfbb78d10a7b73e36de76391ff9d10d43350a75/src/routes/safe/components/Apps/components/AppFrame.tsx#L399) in safe-react
