### PR TITLE
fix(safe-claiming-app): Update guardian data and image urls

### DIFF
--- a/apps/safe-claiming-app/src/config/constants.ts
+++ b/apps/safe-claiming-app/src/config/constants.ts
@@ -20,13 +20,11 @@ export const USER_AIRDROP_ADDRESS = "0x6C6ea0B60873255bb670F838b03db9d9a8f045c4"
 export const ECOSYSTEM_AIRDROP_ADDRESS =
   "0x82F1267759e9Bea202a46f8FC04704b6A5E2Af77"
 
-// TODO: Update URL once deployed to prod
 export const GUARDIANS_URL =
-  "https://5afe.github.io/claiming-app-data/resources/data/guardians.json"
+  "https://safe-claiming-app-data.gnosis-safe.io/guardians/guardians.json"
 
-// TODO: Update URL once deployed to prod
 export const GUARDIANS_IMAGE_URL =
-  "https://5afe.github.io/claiming-app-data/resources/data/images/"
+  "https://safe-claiming-app-data.gnosis-safe.io/guardians/images/"
 
 export const VESTING_URL =
   "https://safe-claiming-app-data.gnosis-safe.io/allocations/"


### PR DESCRIPTION
## What it solves

Updates the guardian data and guardian image urls

## How to test

1. Open the safe-claiming-app with an eligible safe
2. Navigate to the delegate screen
3. Observe guardians being listed with their images