### PR TITLE
fix(safe-claiming-app): Add missing contract addresses and delegateId

### DIFF
--- a/apps/safe-claiming-app/src/App.tsx
+++ b/apps/safe-claiming-app/src/App.tsx
@@ -1,5 +1,5 @@
 import { useSafeAppsSDK } from "@gnosis.pm/safe-apps-react-sdk"
-import { Typography, CircularProgress, styled } from "@mui/material"
+import { styled } from "@mui/material"
 import {
   lazy,
   ReactElement,
@@ -13,11 +13,10 @@ import {
 import { ProgressBar } from "src/components/helpers/ProgressBar"
 import { useLocalStorage } from "src/hooks/useLocalStorage"
 import { FloatingTiles } from "./components/helpers/FloatingTiles"
+import { Loading } from "./components/helpers/Loading"
 import { ScrollContextProvider } from "./components/helpers/ScrollContext"
-import {
-  ECOSYSTEM_AIRDROP_ADDRESSES,
-  USER_AIRDROP_ADDRESSES,
-} from "./config/constants"
+import { UnsupportedNetwork } from "./components/helpers/UnsupportedNetwork"
+import { CHAIN_CONSTANTS } from "./config/constants"
 import theme from "./config/theme"
 import { useAirdropFile } from "./hooks/useAirdropFile"
 import { useDelegate } from "./hooks/useDelegate"
@@ -118,6 +117,8 @@ const App = (): ReactElement => {
 
   const { safe } = useSafeAppsSDK()
 
+  const chainConstants = CHAIN_CONSTANTS[safe.chainId]
+
   const [delegates] = useDelegatesFile()
 
   const [vestings, isVestingLoading] = useAirdropFile()
@@ -125,13 +126,13 @@ const App = (): ReactElement => {
 
   const userVestingStatus = useFetchVestingStatus(
     userVesting?.vestingId,
-    USER_AIRDROP_ADDRESSES[safe.chainId],
+    chainConstants?.userAirdropAddress,
     appState.lastClaimTimestamp
   )
 
   const ecosystemVestingStatus = useFetchVestingStatus(
     ecosystemVesting?.vestingId,
-    ECOSYSTEM_AIRDROP_ADDRESSES[safe.chainId],
+    chainConstants?.ecosystemAirdropAddress,
     appState.lastClaimTimestamp
   )
 
@@ -225,10 +226,12 @@ const App = (): ReactElement => {
 
   const progress = hasNoAirdrop ? 0 : activeStep / (steps.length - 2)
 
+  const unsupportedChain = safe.chainId !== 1 && safe.chainId !== 4
+
   return (
     <>
       <FloatingTiles
-        maxTiles={72}
+        maxTiles={unsupportedChain ? 12 : 72}
         progress={progress}
         color={
           hasNoAirdrop
@@ -239,19 +242,13 @@ const App = (): ReactElement => {
 
       <ScrollContextProvider>
         <Container>
-          {safe.chainId !== 1 && safe.chainId !== 4 ? (
-            <Typography variant="h1">
-              Only Mainnet and Rinkeby are supported by this app.
-            </Typography>
+          {unsupportedChain ? (
+            <UnsupportedNetwork />
           ) : (
             <div>
               {typeof userVesting === "undefined" ||
               typeof ecosystemVesting === "undefined" ? (
-                <div>
-                  <Typography variant="h3">
-                    <CircularProgress /> Loading airdrop data for connected safe
-                  </Typography>
-                </div>
+                <Loading />
               ) : (
                 <>
                   {!hasNoAirdrop && <ProgressBar progress={progress} />}

--- a/apps/safe-claiming-app/src/App.tsx
+++ b/apps/safe-claiming-app/src/App.tsx
@@ -16,7 +16,7 @@ import { FloatingTiles } from "./components/helpers/FloatingTiles"
 import { Loading } from "./components/helpers/Loading"
 import { ScrollContextProvider } from "./components/helpers/ScrollContext"
 import { UnsupportedNetwork } from "./components/helpers/UnsupportedNetwork"
-import { CHAIN_CONSTANTS } from "./config/constants"
+import { Chains, CHAIN_CONSTANTS } from "./config/constants"
 import theme from "./config/theme"
 import { useAirdropFile } from "./hooks/useAirdropFile"
 import { useDelegate } from "./hooks/useDelegate"
@@ -126,13 +126,13 @@ const App = (): ReactElement => {
 
   const userVestingStatus = useFetchVestingStatus(
     userVesting?.vestingId,
-    chainConstants?.userAirdropAddress,
+    chainConstants?.USER_AIRDROP_ADDRESS,
     appState.lastClaimTimestamp
   )
 
   const ecosystemVestingStatus = useFetchVestingStatus(
     ecosystemVesting?.vestingId,
-    chainConstants?.ecosystemAirdropAddress,
+    chainConstants?.ECOSYSTEM_AIRDROP_ADDRESS,
     appState.lastClaimTimestamp
   )
 
@@ -153,6 +153,8 @@ const App = (): ReactElement => {
   const isTokenPaused = useIsTokenPaused()
 
   const delegateAddressFromContract = useDelegate()
+
+  console.log(delegateAddressFromContract)
 
   const currentDelegate = useMemo(() => {
     if (appState.delegate) {
@@ -226,7 +228,8 @@ const App = (): ReactElement => {
 
   const progress = hasNoAirdrop ? 0 : activeStep / (steps.length - 2)
 
-  const unsupportedChain = safe.chainId !== 1 && safe.chainId !== 4
+  const unsupportedChain =
+    safe.chainId !== Chains.MAINNET && safe.chainId !== Chains.RINKEBY
 
   return (
     <>

--- a/apps/safe-claiming-app/src/App.tsx
+++ b/apps/safe-claiming-app/src/App.tsx
@@ -154,8 +154,6 @@ const App = (): ReactElement => {
 
   const delegateAddressFromContract = useDelegate()
 
-  console.log(delegateAddressFromContract)
-
   const currentDelegate = useMemo(() => {
     if (appState.delegate) {
       return appState.delegate

--- a/apps/safe-claiming-app/src/App.tsx
+++ b/apps/safe-claiming-app/src/App.tsx
@@ -15,8 +15,8 @@ import { useLocalStorage } from "src/hooks/useLocalStorage"
 import { FloatingTiles } from "./components/helpers/FloatingTiles"
 import { ScrollContextProvider } from "./components/helpers/ScrollContext"
 import {
-  ECOSYSTEM_AIRDROP_ADDRESS,
-  USER_AIRDROP_ADDRESS,
+  ECOSYSTEM_AIRDROP_ADDRESSES,
+  USER_AIRDROP_ADDRESSES,
 } from "./config/constants"
 import theme from "./config/theme"
 import { useAirdropFile } from "./hooks/useAirdropFile"
@@ -125,13 +125,13 @@ const App = (): ReactElement => {
 
   const userVestingStatus = useFetchVestingStatus(
     userVesting?.vestingId,
-    USER_AIRDROP_ADDRESS,
+    USER_AIRDROP_ADDRESSES[safe.chainId],
     appState.lastClaimTimestamp
   )
 
   const ecosystemVestingStatus = useFetchVestingStatus(
     ecosystemVesting?.vestingId,
-    ECOSYSTEM_AIRDROP_ADDRESS,
+    ECOSYSTEM_AIRDROP_ADDRESSES[safe.chainId],
     appState.lastClaimTimestamp
   )
 

--- a/apps/safe-claiming-app/src/components/helpers/Loading.tsx
+++ b/apps/safe-claiming-app/src/components/helpers/Loading.tsx
@@ -15,7 +15,7 @@ export const Loading = () => {
       }}
     >
       <Typography variant="h3">
-        <CircularProgress /> Loading airdrop data for connected safe
+        <CircularProgress /> Loading airdrop data for connected Safe
       </Typography>
     </Paper>
   )

--- a/apps/safe-claiming-app/src/components/helpers/Loading.tsx
+++ b/apps/safe-claiming-app/src/components/helpers/Loading.tsx
@@ -1,0 +1,22 @@
+import { CircularProgress, Paper, Typography } from "@mui/material"
+
+export const Loading = () => {
+  return (
+    <Paper
+      elevation={0}
+      sx={{
+        paddingX: 6,
+        paddingY: 12,
+        textAlign: "center",
+        display: "flex",
+        alignItems: "center",
+        flexDirection: "column",
+        height: 1,
+      }}
+    >
+      <Typography variant="h3">
+        <CircularProgress /> Loading airdrop data for connected safe
+      </Typography>
+    </Paper>
+  )
+}

--- a/apps/safe-claiming-app/src/components/helpers/UnsupportedNetwork.tsx
+++ b/apps/safe-claiming-app/src/components/helpers/UnsupportedNetwork.tsx
@@ -1,0 +1,22 @@
+import { Paper, Typography } from "@mui/material"
+
+export const UnsupportedNetwork = () => {
+  return (
+    <Paper
+      elevation={0}
+      sx={{
+        paddingX: 6,
+        paddingY: 12,
+        textAlign: "center",
+        display: "flex",
+        alignItems: "center",
+        flexDirection: "column",
+        height: 1,
+      }}
+    >
+      <Typography variant="h3">
+        Only Mainnet and Rinkeby are supported by this Safe App
+      </Typography>
+    </Paper>
+  )
+}

--- a/apps/safe-claiming-app/src/components/steps/Claim/index.tsx
+++ b/apps/safe-claiming-app/src/components/steps/Claim/index.tsx
@@ -124,7 +124,7 @@ const Claim = ({ handleBack, state, handleUpdateState, handleNext }: Props) => {
           userClaim,
           userAmount,
           safe.safeAddress,
-          chainConstants.userAirdropAddress,
+          chainConstants.USER_AIRDROP_ADDRESS,
           isTokenPaused
         )
       )
@@ -136,7 +136,7 @@ const Claim = ({ handleBack, state, handleUpdateState, handleNext }: Props) => {
           ecosystemClaim,
           ecosystemAmount,
           safe.safeAddress,
-          chainConstants.ecosystemAirdropAddress,
+          chainConstants.ECOSYSTEM_AIRDROP_ADDRESS,
           isTokenPaused
         )
       )

--- a/apps/safe-claiming-app/src/components/steps/Claim/index.tsx
+++ b/apps/safe-claiming-app/src/components/steps/Claim/index.tsx
@@ -18,10 +18,6 @@ import { maxDecimals, minMaxValue, mustBeFloat } from "src/utils/validation"
 
 import { useSafeAppsSDK } from "@gnosis.pm/safe-apps-react-sdk"
 import { BigNumber, ethers } from "ethers"
-import {
-  ECOSYSTEM_AIRDROP_ADDRESSES,
-  USER_AIRDROP_ADDRESSES,
-} from "src/config/constants"
 import { useAmounts } from "src/hooks/useAmounts"
 import { createAirdropTxs } from "src/utils/contracts/airdrop"
 import { createDelegateTx } from "src/utils/contracts/delegateRegistry"
@@ -30,6 +26,7 @@ import { InfoOutlined } from "@mui/icons-material"
 import { ClaimCard } from "./ClaimCard"
 import { formatAmount } from "src/utils/format"
 import { NavButtons } from "src/components/helpers/NavButtons"
+import { CHAIN_CONSTANTS } from "src/config/constants"
 
 const ButtonLink = styled("button")`
   border: 0;
@@ -58,6 +55,8 @@ const validateAmount = (amount: string, maxAmount: string) => {
 
 const Claim = ({ handleBack, state, handleUpdateState, handleNext }: Props) => {
   const { sdk, safe } = useSafeAppsSDK()
+
+  const chainConstants = CHAIN_CONSTANTS[safe.chainId]
 
   const { delegate, userClaim, ecosystemClaim, isTokenPaused } = state
   const [amount, setAmount] = useState<string>()
@@ -125,7 +124,7 @@ const Claim = ({ handleBack, state, handleUpdateState, handleNext }: Props) => {
           userClaim,
           userAmount,
           safe.safeAddress,
-          USER_AIRDROP_ADDRESSES[safe.chainId],
+          chainConstants.userAirdropAddress,
           isTokenPaused
         )
       )
@@ -137,7 +136,7 @@ const Claim = ({ handleBack, state, handleUpdateState, handleNext }: Props) => {
           ecosystemClaim,
           ecosystemAmount,
           safe.safeAddress,
-          ECOSYSTEM_AIRDROP_ADDRESSES[safe.chainId],
+          chainConstants.ecosystemAirdropAddress,
           isTokenPaused
         )
       )

--- a/apps/safe-claiming-app/src/components/steps/Claim/index.tsx
+++ b/apps/safe-claiming-app/src/components/steps/Claim/index.tsx
@@ -19,8 +19,8 @@ import { maxDecimals, minMaxValue, mustBeFloat } from "src/utils/validation"
 import { useSafeAppsSDK } from "@gnosis.pm/safe-apps-react-sdk"
 import { BigNumber, ethers } from "ethers"
 import {
-  ECOSYSTEM_AIRDROP_ADDRESS,
-  USER_AIRDROP_ADDRESS,
+  ECOSYSTEM_AIRDROP_ADDRESSES,
+  USER_AIRDROP_ADDRESSES,
 } from "src/config/constants"
 import { useAmounts } from "src/hooks/useAmounts"
 import { createAirdropTxs } from "src/utils/contracts/airdrop"
@@ -108,7 +108,7 @@ const Claim = ({ handleBack, state, handleUpdateState, handleNext }: Props) => {
       state.delegateAddressFromContract !== state.delegate.address
 
     if (hasDelegateChanged) {
-      const delegateTx = createDelegateTx(state.delegate.address)
+      const delegateTx = createDelegateTx(state.delegate.address, safe.chainId)
       txs.push(delegateTx)
     }
 
@@ -125,7 +125,7 @@ const Claim = ({ handleBack, state, handleUpdateState, handleNext }: Props) => {
           userClaim,
           userAmount,
           safe.safeAddress,
-          USER_AIRDROP_ADDRESS,
+          USER_AIRDROP_ADDRESSES[safe.chainId],
           isTokenPaused
         )
       )
@@ -137,7 +137,7 @@ const Claim = ({ handleBack, state, handleUpdateState, handleNext }: Props) => {
           ecosystemClaim,
           ecosystemAmount,
           safe.safeAddress,
-          ECOSYSTEM_AIRDROP_ADDRESS,
+          ECOSYSTEM_AIRDROP_ADDRESSES[safe.chainId],
           isTokenPaused
         )
       )

--- a/apps/safe-claiming-app/src/config/constants.ts
+++ b/apps/safe-claiming-app/src/config/constants.ts
@@ -10,15 +10,25 @@ export const DelegateRegistryAddress =
   "0x469788fe6e9e9681c6ebf3bf78e7fd26fc015446"
 export const DelegateID = "safe.eth"
 
-// FIXME testing SAFE token
-export const SAFE_TOKEN_ADDRESS = "0xCFf1b0FdE85C102552D1D96084AF148f478F964A"
+export const DelegateIDs: Record<number, string> = {
+  1: "safe.eth",
+  4: "tutis.eth",
+}
 
-// FIXME testing airdrop address
-export const USER_AIRDROP_ADDRESS = "0x6C6ea0B60873255bb670F838b03db9d9a8f045c4"
+export const SAFE_TOKEN_ADDRESSES: Record<number, string> = {
+  1: "0x5afe3855358e112b5647b952709e6165e1c1eeee",
+  4: "0xCFf1b0FdE85C102552D1D96084AF148f478F964A",
+}
 
-//FIXME testing airdrop address
-export const ECOSYSTEM_AIRDROP_ADDRESS =
-  "0x82F1267759e9Bea202a46f8FC04704b6A5E2Af77"
+export const USER_AIRDROP_ADDRESSES: Record<number, string> = {
+  1: "0x590d38Af0b484e7FB9a54a9669dcfFFB25D2DF35",
+  4: "0x6C6ea0B60873255bb670F838b03db9d9a8f045c4",
+}
+
+export const ECOSYSTEM_AIRDROP_ADDRESSES: Record<number, string> = {
+  1: "0x3eCD46C973d815e30F604619B7F3EB9B30c0e963",
+  4: "0x82F1267759e9Bea202a46f8FC04704b6A5E2Af77",
+}
 
 export const GUARDIANS_URL =
   "https://safe-claiming-app-data.gnosis-safe.io/guardians/guardians.json"

--- a/apps/safe-claiming-app/src/config/constants.ts
+++ b/apps/safe-claiming-app/src/config/constants.ts
@@ -1,10 +1,15 @@
 import { BigNumber } from "ethers"
 
 type ChainConstants = {
-  delegateID: string
-  safeTokenAddress: string
-  userAirdropAddress: string
-  ecosystemAirdropAddress: string
+  DELEGATE_ID: string
+  SAFE_TOKEN_ADDRESS: string
+  USER_AIRDROP_ADDRESS: string
+  ECOSYSTEM_AIRDROP_ADDRESS: string
+}
+
+export enum Chains {
+  RINKEBY = 4,
+  MAINNET = 1,
 }
 
 export const STORAGE_PREFIX = "SAFE__"
@@ -37,15 +42,15 @@ export const FULL_PROPOSAL_URL =
 
 export const CHAIN_CONSTANTS: Record<number, ChainConstants> = {
   1: {
-    delegateID: "safe.eth",
-    ecosystemAirdropAddress: "0x3eCD46C973d815e30F604619B7F3EB9B30c0e963",
-    userAirdropAddress: "0x590d38Af0b484e7FB9a54a9669dcfFFB25D2DF35",
-    safeTokenAddress: "0x5afe3855358e112b5647b952709e6165e1c1eeee",
+    DELEGATE_ID: "safe.eth",
+    ECOSYSTEM_AIRDROP_ADDRESS: "0x3eCD46C973d815e30F604619B7F3EB9B30c0e963",
+    USER_AIRDROP_ADDRESS: "0x590d38Af0b484e7FB9a54a9669dcfFFB25D2DF35",
+    SAFE_TOKEN_ADDRESS: "0x5afe3855358e112b5647b952709e6165e1c1eeee",
   },
   4: {
-    delegateID: "tutis.eth",
-    ecosystemAirdropAddress: "0x82F1267759e9Bea202a46f8FC04704b6A5E2Af77",
-    userAirdropAddress: "0x6C6ea0B60873255bb670F838b03db9d9a8f045c4",
-    safeTokenAddress: "0xCFf1b0FdE85C102552D1D96084AF148f478F964A",
+    DELEGATE_ID: "tutis.eth",
+    ECOSYSTEM_AIRDROP_ADDRESS: "0x82F1267759e9Bea202a46f8FC04704b6A5E2Af77",
+    USER_AIRDROP_ADDRESS: "0x6C6ea0B60873255bb670F838b03db9d9a8f045c4",
+    SAFE_TOKEN_ADDRESS: "0xCFf1b0FdE85C102552D1D96084AF148f478F964A",
   },
 }

--- a/apps/safe-claiming-app/src/config/constants.ts
+++ b/apps/safe-claiming-app/src/config/constants.ts
@@ -1,5 +1,12 @@
 import { BigNumber } from "ethers"
 
+type ChainConstants = {
+  delegateID: string
+  safeTokenAddress: string
+  userAirdropAddress: string
+  ecosystemAirdropAddress: string
+}
+
 export const STORAGE_PREFIX = "SAFE__"
 
 export const MAX_UINT128 = BigNumber.from("0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF")
@@ -8,27 +15,6 @@ export const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000"
 
 export const DelegateRegistryAddress =
   "0x469788fe6e9e9681c6ebf3bf78e7fd26fc015446"
-export const DelegateID = "safe.eth"
-
-export const DelegateIDs: Record<number, string> = {
-  1: "safe.eth",
-  4: "tutis.eth",
-}
-
-export const SAFE_TOKEN_ADDRESSES: Record<number, string> = {
-  1: "0x5afe3855358e112b5647b952709e6165e1c1eeee",
-  4: "0xCFf1b0FdE85C102552D1D96084AF148f478F964A",
-}
-
-export const USER_AIRDROP_ADDRESSES: Record<number, string> = {
-  1: "0x590d38Af0b484e7FB9a54a9669dcfFFB25D2DF35",
-  4: "0x6C6ea0B60873255bb670F838b03db9d9a8f045c4",
-}
-
-export const ECOSYSTEM_AIRDROP_ADDRESSES: Record<number, string> = {
-  1: "0x3eCD46C973d815e30F604619B7F3EB9B30c0e963",
-  4: "0x82F1267759e9Bea202a46f8FC04704b6A5E2Af77",
-}
 
 export const GUARDIANS_URL =
   "https://safe-claiming-app-data.gnosis-safe.io/guardians/guardians.json"
@@ -48,3 +34,18 @@ export const GOVERNANCE_URL =
 
 export const FULL_PROPOSAL_URL =
   "https://forum.gnosis-safe.io/t/safe-voting-power-and-circulating-supply/558"
+
+export const CHAIN_CONSTANTS: Record<number, ChainConstants> = {
+  1: {
+    delegateID: "safe.eth",
+    ecosystemAirdropAddress: "0x3eCD46C973d815e30F604619B7F3EB9B30c0e963",
+    userAirdropAddress: "0x590d38Af0b484e7FB9a54a9669dcfFFB25D2DF35",
+    safeTokenAddress: "0x5afe3855358e112b5647b952709e6165e1c1eeee",
+  },
+  4: {
+    delegateID: "tutis.eth",
+    ecosystemAirdropAddress: "0x82F1267759e9Bea202a46f8FC04704b6A5E2Af77",
+    userAirdropAddress: "0x6C6ea0B60873255bb670F838b03db9d9a8f045c4",
+    safeTokenAddress: "0xCFf1b0FdE85C102552D1D96084AF148f478F964A",
+  },
+}

--- a/apps/safe-claiming-app/src/hooks/__tests__/useDelegate.test.ts
+++ b/apps/safe-claiming-app/src/hooks/__tests__/useDelegate.test.ts
@@ -45,7 +45,7 @@ describe("useDelegate()", () => {
 
   it("ignore the ZERO_ADDRESS as delegate", async () => {
     const delegateIDInBytes = ethers.utils.formatBytes32String(
-      CHAIN_CONSTANTS[4].delegateID
+      CHAIN_CONSTANTS[4].DELEGATE_ID
     )
 
     web3Provider.call = jest.fn((transaction) => {
@@ -74,7 +74,7 @@ describe("useDelegate()", () => {
 
   it("should encode the correct data and fetch the delegate on-chain once", async () => {
     const delegateIDInBytes = ethers.utils.formatBytes32String(
-      CHAIN_CONSTANTS[4].delegateID
+      CHAIN_CONSTANTS[4].DELEGATE_ID
     )
     const delegateAddress = ethers.utils.hexZeroPad("0x1", 20)
 

--- a/apps/safe-claiming-app/src/hooks/__tests__/useDelegate.test.ts
+++ b/apps/safe-claiming-app/src/hooks/__tests__/useDelegate.test.ts
@@ -2,7 +2,7 @@ import { waitFor } from "@testing-library/react"
 import { renderHook } from "@testing-library/react-hooks"
 import { ethers } from "ethers"
 import {
-  DelegateID,
+  DelegateIDs,
   DelegateRegistryAddress,
   ZERO_ADDRESS,
 } from "src/config/constants"
@@ -22,7 +22,10 @@ jest.mock("@gnosis.pm/safe-apps-react-sdk", () => {
     // We require some of the enums/types from the original module
     ...originalModule,
     useSafeAppsSDK: () => ({
-      safe: { safeAddress: "0x6a13E0280740CC5bd35eeee33B470b5bBb93dF37" },
+      safe: {
+        safeAddress: "0x6a13E0280740CC5bd35eeee33B470b5bBb93dF37",
+        chainId: 4,
+      },
       sdk: undefined,
     }),
   }
@@ -41,7 +44,7 @@ describe("useDelegate()", () => {
   })
 
   it("ignore the ZERO_ADDRESS as delegate", async () => {
-    const delegateIDInBytes = ethers.utils.formatBytes32String(DelegateID)
+    const delegateIDInBytes = ethers.utils.formatBytes32String(DelegateIDs[4])
 
     web3Provider.call = jest.fn((transaction) => {
       expect(transaction.to?.toString().toLowerCase()).toEqual(
@@ -68,7 +71,7 @@ describe("useDelegate()", () => {
   })
 
   it("should encode the correct data and fetch the delegate on-chain once", async () => {
-    const delegateIDInBytes = ethers.utils.formatBytes32String(DelegateID)
+    const delegateIDInBytes = ethers.utils.formatBytes32String(DelegateIDs[4])
     const delegateAddress = ethers.utils.hexZeroPad("0x1", 20)
 
     web3Provider.call = jest.fn((transaction) => {

--- a/apps/safe-claiming-app/src/hooks/__tests__/useDelegate.test.ts
+++ b/apps/safe-claiming-app/src/hooks/__tests__/useDelegate.test.ts
@@ -2,7 +2,7 @@ import { waitFor } from "@testing-library/react"
 import { renderHook } from "@testing-library/react-hooks"
 import { ethers } from "ethers"
 import {
-  DelegateIDs,
+  CHAIN_CONSTANTS,
   DelegateRegistryAddress,
   ZERO_ADDRESS,
 } from "src/config/constants"
@@ -44,7 +44,9 @@ describe("useDelegate()", () => {
   })
 
   it("ignore the ZERO_ADDRESS as delegate", async () => {
-    const delegateIDInBytes = ethers.utils.formatBytes32String(DelegateIDs[4])
+    const delegateIDInBytes = ethers.utils.formatBytes32String(
+      CHAIN_CONSTANTS[4].delegateID
+    )
 
     web3Provider.call = jest.fn((transaction) => {
       expect(transaction.to?.toString().toLowerCase()).toEqual(
@@ -71,7 +73,9 @@ describe("useDelegate()", () => {
   })
 
   it("should encode the correct data and fetch the delegate on-chain once", async () => {
-    const delegateIDInBytes = ethers.utils.formatBytes32String(DelegateIDs[4])
+    const delegateIDInBytes = ethers.utils.formatBytes32String(
+      CHAIN_CONSTANTS[4].delegateID
+    )
     const delegateAddress = ethers.utils.hexZeroPad("0x1", 20)
 
     web3Provider.call = jest.fn((transaction) => {

--- a/apps/safe-claiming-app/src/hooks/__tests__/useFetchVestingStatus.test.ts
+++ b/apps/safe-claiming-app/src/hooks/__tests__/useFetchVestingStatus.test.ts
@@ -42,7 +42,11 @@ describe("useFetchVestingStatus", () => {
 
   it("returns undefined for undefined vestingId", () => {
     const { result } = renderHook(() =>
-      useFetchVestingStatus(undefined, CHAIN_CONSTANTS[4].userAirdropAddress, 1)
+      useFetchVestingStatus(
+        undefined,
+        CHAIN_CONSTANTS[4].USER_AIRDROP_ADDRESS,
+        1
+      )
     )
 
     expect(result.current).toBeUndefined()
@@ -55,7 +59,7 @@ describe("useFetchVestingStatus", () => {
     const { result } = renderHook(() =>
       useFetchVestingStatus(
         hexZeroPad("0x1234", 32),
-        CHAIN_CONSTANTS[4].userAirdropAddress,
+        CHAIN_CONSTANTS[4].USER_AIRDROP_ADDRESS,
         1
       )
     )
@@ -111,7 +115,7 @@ describe("useFetchVestingStatus", () => {
       ({ lastClaimTimestamp }) =>
         useFetchVestingStatus(
           testVestingId,
-          CHAIN_CONSTANTS[4].userAirdropAddress,
+          CHAIN_CONSTANTS[4].USER_AIRDROP_ADDRESS,
           lastClaimTimestamp
         ),
       { initialProps: { lastClaimTimestamp: 1 } }

--- a/apps/safe-claiming-app/src/hooks/__tests__/useFetchVestingStatus.test.ts
+++ b/apps/safe-claiming-app/src/hooks/__tests__/useFetchVestingStatus.test.ts
@@ -1,8 +1,7 @@
 import { act, waitFor } from "@testing-library/react"
 import { renderHook } from "@testing-library/react-hooks"
-import { ethers } from "ethers"
 import { hexZeroPad } from "ethers/lib/utils"
-import { USER_AIRDROP_ADDRESS, ZERO_ADDRESS } from "src/config/constants"
+import { USER_AIRDROP_ADDRESSES, ZERO_ADDRESS } from "src/config/constants"
 import { Airdrop__factory } from "src/types/contracts/factories/Airdrop__factory"
 import { getWeb3Provider } from "src/utils/getWeb3Provider"
 import { useFetchVestingStatus } from "../useFetchVestingStatus"
@@ -43,7 +42,7 @@ describe("useFetchVestingStatus", () => {
 
   it("returns undefined for undefined vestingId", () => {
     const { result } = renderHook(() =>
-      useFetchVestingStatus(undefined, USER_AIRDROP_ADDRESS, 1)
+      useFetchVestingStatus(undefined, USER_AIRDROP_ADDRESSES[4], 1)
     )
 
     expect(result.current).toBeUndefined()
@@ -54,7 +53,11 @@ describe("useFetchVestingStatus", () => {
     const mockCall = jest.fn()
     web3Provider.call = mockCall
     const { result } = renderHook(() =>
-      useFetchVestingStatus(hexZeroPad("0x1234", 32), USER_AIRDROP_ADDRESS, 1)
+      useFetchVestingStatus(
+        hexZeroPad("0x1234", 32),
+        USER_AIRDROP_ADDRESSES[4],
+        1
+      )
     )
     await waitFor(() => {
       expect(result.current).toBeUndefined()
@@ -108,7 +111,7 @@ describe("useFetchVestingStatus", () => {
       ({ lastClaimTimestamp }) =>
         useFetchVestingStatus(
           testVestingId,
-          USER_AIRDROP_ADDRESS,
+          USER_AIRDROP_ADDRESSES[4],
           lastClaimTimestamp
         ),
       { initialProps: { lastClaimTimestamp: 1 } }

--- a/apps/safe-claiming-app/src/hooks/__tests__/useFetchVestingStatus.test.ts
+++ b/apps/safe-claiming-app/src/hooks/__tests__/useFetchVestingStatus.test.ts
@@ -1,7 +1,7 @@
 import { act, waitFor } from "@testing-library/react"
 import { renderHook } from "@testing-library/react-hooks"
 import { hexZeroPad } from "ethers/lib/utils"
-import { USER_AIRDROP_ADDRESSES, ZERO_ADDRESS } from "src/config/constants"
+import { CHAIN_CONSTANTS, ZERO_ADDRESS } from "src/config/constants"
 import { Airdrop__factory } from "src/types/contracts/factories/Airdrop__factory"
 import { getWeb3Provider } from "src/utils/getWeb3Provider"
 import { useFetchVestingStatus } from "../useFetchVestingStatus"
@@ -42,7 +42,7 @@ describe("useFetchVestingStatus", () => {
 
   it("returns undefined for undefined vestingId", () => {
     const { result } = renderHook(() =>
-      useFetchVestingStatus(undefined, USER_AIRDROP_ADDRESSES[4], 1)
+      useFetchVestingStatus(undefined, CHAIN_CONSTANTS[4].userAirdropAddress, 1)
     )
 
     expect(result.current).toBeUndefined()
@@ -55,7 +55,7 @@ describe("useFetchVestingStatus", () => {
     const { result } = renderHook(() =>
       useFetchVestingStatus(
         hexZeroPad("0x1234", 32),
-        USER_AIRDROP_ADDRESSES[4],
+        CHAIN_CONSTANTS[4].userAirdropAddress,
         1
       )
     )
@@ -111,7 +111,7 @@ describe("useFetchVestingStatus", () => {
       ({ lastClaimTimestamp }) =>
         useFetchVestingStatus(
           testVestingId,
-          USER_AIRDROP_ADDRESSES[4],
+          CHAIN_CONSTANTS[4].userAirdropAddress,
           lastClaimTimestamp
         ),
       { initialProps: { lastClaimTimestamp: 1 } }

--- a/apps/safe-claiming-app/src/hooks/__tests__/useIsTokenPaused.test.ts
+++ b/apps/safe-claiming-app/src/hooks/__tests__/useIsTokenPaused.test.ts
@@ -17,7 +17,7 @@ jest.mock("@gnosis.pm/safe-apps-react-sdk", () => {
     useSafeAppsSDK: () => ({
       safe: {
         safeAddress: "0x6a13E0280740CC5bd35eeee33B470b5bBb93dF37",
-        chainId: "4",
+        chainId: 4,
       },
       sdk: undefined,
     }),

--- a/apps/safe-claiming-app/src/hooks/useDelegate.ts
+++ b/apps/safe-claiming-app/src/hooks/useDelegate.ts
@@ -1,7 +1,7 @@
 import { useSafeAppsSDK } from "@gnosis.pm/safe-apps-react-sdk"
 import { Contract, ethers } from "ethers"
 import {
-  DelegateIDs,
+  CHAIN_CONSTANTS,
   DelegateRegistryAddress,
   ZERO_ADDRESS,
 } from "src/config/constants"
@@ -15,11 +15,16 @@ export const useDelegate = () => {
 
   const ethersProvider = useMemo(() => getWeb3Provider(safe, sdk), [safe, sdk])
 
+  const chainConstants = CHAIN_CONSTANTS[safe.chainId]
+
   useEffect(() => {
+    if (!chainConstants) {
+      return
+    }
     let isCurrent = true
 
     const delegateIDInBytes = ethers.utils.formatBytes32String(
-      DelegateIDs[safe.chainId]
+      chainConstants.delegateID
     )
 
     const checkDelegate = async () => {
@@ -43,7 +48,7 @@ export const useDelegate = () => {
     return () => {
       isCurrent = false
     }
-  }, [ethersProvider, safe.safeAddress])
+  }, [chainConstants, ethersProvider, safe.safeAddress])
 
   return delegateAddress
 }

--- a/apps/safe-claiming-app/src/hooks/useDelegate.ts
+++ b/apps/safe-claiming-app/src/hooks/useDelegate.ts
@@ -1,7 +1,7 @@
 import { useSafeAppsSDK } from "@gnosis.pm/safe-apps-react-sdk"
 import { Contract, ethers } from "ethers"
 import {
-  DelegateID,
+  DelegateIDs,
   DelegateRegistryAddress,
   ZERO_ADDRESS,
 } from "src/config/constants"
@@ -18,7 +18,9 @@ export const useDelegate = () => {
   useEffect(() => {
     let isCurrent = true
 
-    const delegateIDInBytes = ethers.utils.formatBytes32String(DelegateID)
+    const delegateIDInBytes = ethers.utils.formatBytes32String(
+      DelegateIDs[safe.chainId]
+    )
 
     const checkDelegate = async () => {
       const abiInterface = new Interface([

--- a/apps/safe-claiming-app/src/hooks/useDelegate.ts
+++ b/apps/safe-claiming-app/src/hooks/useDelegate.ts
@@ -24,7 +24,7 @@ export const useDelegate = () => {
     let isCurrent = true
 
     const delegateIDInBytes = ethers.utils.formatBytes32String(
-      chainConstants.delegateID
+      chainConstants.DELEGATE_ID
     )
 
     const checkDelegate = async () => {

--- a/apps/safe-claiming-app/src/hooks/useIsTokenPaused.ts
+++ b/apps/safe-claiming-app/src/hooks/useIsTokenPaused.ts
@@ -1,6 +1,6 @@
 import { useSafeAppsSDK } from "@gnosis.pm/safe-apps-react-sdk"
 import { useEffect, useState } from "react"
-import { SAFE_TOKEN_ADDRESSES } from "src/config/constants"
+import { CHAIN_CONSTANTS } from "src/config/constants"
 import { SafeToken__factory } from "src/types/contracts/factories/SafeToken__factory"
 import { getWeb3Provider } from "src/utils/getWeb3Provider"
 
@@ -12,6 +12,7 @@ export const useIsTokenPaused = () => {
   const [isPaused, setIsPaused] = useState(true)
   const { safe, sdk } = useSafeAppsSDK()
   const web3Provider = getWeb3Provider(safe, sdk)
+  const chainConstants = CHAIN_CONSTANTS[safe.chainId]
 
   useEffect(() => {
     let isMounted = true
@@ -19,7 +20,7 @@ export const useIsTokenPaused = () => {
     const fetchIsTokenPaused = async () => {
       try {
         const paused = await SafeToken__factory.connect(
-          SAFE_TOKEN_ADDRESSES[safe.chainId],
+          chainConstants.safeTokenAddress,
           web3Provider
         ).paused()
 
@@ -28,12 +29,13 @@ export const useIsTokenPaused = () => {
         console.error(error)
       }
     }
-
-    fetchIsTokenPaused()
+    if (chainConstants) {
+      fetchIsTokenPaused()
+    }
     return () => {
       isMounted = false
     }
-  }, [web3Provider])
+  }, [chainConstants, web3Provider])
 
   return isPaused
 }

--- a/apps/safe-claiming-app/src/hooks/useIsTokenPaused.ts
+++ b/apps/safe-claiming-app/src/hooks/useIsTokenPaused.ts
@@ -20,7 +20,7 @@ export const useIsTokenPaused = () => {
     const fetchIsTokenPaused = async () => {
       try {
         const paused = await SafeToken__factory.connect(
-          chainConstants.safeTokenAddress,
+          chainConstants.SAFE_TOKEN_ADDRESS,
           web3Provider
         ).paused()
 

--- a/apps/safe-claiming-app/src/hooks/useIsTokenPaused.ts
+++ b/apps/safe-claiming-app/src/hooks/useIsTokenPaused.ts
@@ -1,6 +1,6 @@
 import { useSafeAppsSDK } from "@gnosis.pm/safe-apps-react-sdk"
 import { useEffect, useState } from "react"
-import { SAFE_TOKEN_ADDRESS } from "src/config/constants"
+import { SAFE_TOKEN_ADDRESSES } from "src/config/constants"
 import { SafeToken__factory } from "src/types/contracts/factories/SafeToken__factory"
 import { getWeb3Provider } from "src/utils/getWeb3Provider"
 
@@ -19,7 +19,7 @@ export const useIsTokenPaused = () => {
     const fetchIsTokenPaused = async () => {
       try {
         const paused = await SafeToken__factory.connect(
-          SAFE_TOKEN_ADDRESS,
+          SAFE_TOKEN_ADDRESSES[safe.chainId],
           web3Provider
         ).paused()
 

--- a/apps/safe-claiming-app/src/utils/contracts/delegateRegistry.ts
+++ b/apps/safe-claiming-app/src/utils/contracts/delegateRegistry.ts
@@ -1,14 +1,16 @@
 import { ethers } from "ethers"
 import { Interface } from "ethers/lib/utils"
-import { DelegateIDs, DelegateRegistryAddress } from "src/config/constants"
+import { CHAIN_CONSTANTS, DelegateRegistryAddress } from "src/config/constants"
 
 export const createDelegateTx = (delegateAddress: string, chainId: number) => {
+  const chainConstants = CHAIN_CONSTANTS[chainId]
+
   const delegateContractInterface = new Interface([
     "function delegation(bytes32, bytes32) public view returns (address)",
     "function setDelegate(bytes32 id, address delegate) public",
   ])
   // Add delegate tx if necessary
-  const delegateId = ethers.utils.formatBytes32String(DelegateIDs[chainId])
+  const delegateId = ethers.utils.formatBytes32String(chainConstants.delegateID)
   const delegateData = delegateContractInterface.encodeFunctionData(
     "setDelegate",
     [delegateId, delegateAddress]

--- a/apps/safe-claiming-app/src/utils/contracts/delegateRegistry.ts
+++ b/apps/safe-claiming-app/src/utils/contracts/delegateRegistry.ts
@@ -1,14 +1,14 @@
 import { ethers } from "ethers"
 import { Interface } from "ethers/lib/utils"
-import { DelegateID, DelegateRegistryAddress } from "src/config/constants"
+import { DelegateIDs, DelegateRegistryAddress } from "src/config/constants"
 
-export const createDelegateTx = (delegateAddress: string) => {
+export const createDelegateTx = (delegateAddress: string, chainId: number) => {
   const delegateContractInterface = new Interface([
     "function delegation(bytes32, bytes32) public view returns (address)",
     "function setDelegate(bytes32 id, address delegate) public",
   ])
   // Add delegate tx if necessary
-  const delegateId = ethers.utils.formatBytes32String(DelegateID)
+  const delegateId = ethers.utils.formatBytes32String(DelegateIDs[chainId])
   const delegateData = delegateContractInterface.encodeFunctionData(
     "setDelegate",
     [delegateId, delegateAddress]

--- a/apps/safe-claiming-app/src/utils/contracts/delegateRegistry.ts
+++ b/apps/safe-claiming-app/src/utils/contracts/delegateRegistry.ts
@@ -10,7 +10,9 @@ export const createDelegateTx = (delegateAddress: string, chainId: number) => {
     "function setDelegate(bytes32 id, address delegate) public",
   ])
   // Add delegate tx if necessary
-  const delegateId = ethers.utils.formatBytes32String(chainConstants.delegateID)
+  const delegateId = ethers.utils.formatBytes32String(
+    chainConstants.DELEGATE_ID
+  )
   const delegateData = delegateContractInterface.encodeFunctionData(
     "setDelegate",
     [delegateId, delegateAddress]


### PR DESCRIPTION
## What it solves

- Adds missing contract addresses for mainnet
- Adds the test delegateId for rinkeby
- Uses the correct addresses and delegateId depending on the `chainId` of the connected safe

## How to test it

1. Open the safe claiming app with an eligible rinkeby safe
2. The app should display the normal flow
3. Select a delegate
4. Observe a tx being created with the test `delegateId`
