### PR TITLE
fix(claiming-step): adds helper text about deadline

### DIFF
--- a/apps/safe-claiming-app/src/components/steps/Claim/index.tsx
+++ b/apps/safe-claiming-app/src/components/steps/Claim/index.tsx
@@ -195,10 +195,12 @@ const Claim = ({ handleBack, state, handleUpdateState, handleNext }: Props) => {
             color: ({ palette }) => palette.secondary.main,
           }}
         />
-        <Typography variant="subtitle1">
+        <Typography variant="subtitle2">
           Awarded total allocation is{" "}
-          {formatAmount(Number(ethers.utils.formatEther(totalAllocation)), 2)}{" "}
-          SAFE
+          <span style={{ color: "#121312" }}>
+            {formatAmount(Number(ethers.utils.formatEther(totalAllocation)), 2)}{" "}
+            SAFE
+          </span>
         </Typography>
       </Box>
 
@@ -259,11 +261,26 @@ const Claim = ({ handleBack, state, handleUpdateState, handleNext }: Props) => {
                 </Button>
               </Grid>
             </Grid>
+            <Box display="flex" gap={1} mt={0} mb={4}>
+              <InfoOutlined
+                sx={{
+                  height: "16px",
+                  width: "16px",
+                  marginTop: "4px",
+                  color: ({ palette }) => palette.secondary.main,
+                }}
+              />
+              <Typography variant="subtitle2">
+                Execute at least one claim of any amount of tokens until
+                27.12.22 10:00 CET or your allocation will be transferred back
+                to the SafeDAO treasury
+              </Typography>
+            </Box>
           </>
         </Grid>
         {delegate && (
           <Grid item xs={12}>
-            <Typography variant="subtitle1" marginBottom={1}>
+            <Typography variant="body1" marginBottom={1}>
               Delegating to
             </Typography>
             <SelectedDelegate delegate={delegate} onClick={handleBack} />
@@ -276,7 +293,7 @@ const Claim = ({ handleBack, state, handleUpdateState, handleNext }: Props) => {
                   color: ({ palette }) => palette.secondary.main,
                 }}
               />
-              <Typography variant="subtitle1">
+              <Typography variant="subtitle2">
                 You only delegate your voting power and not the ownership over
                 your tokens.
               </Typography>


### PR DESCRIPTION
## What it solves
Adds new helper text about redeem deadline on claiming step.
Also fixes colors of helper texts on claiming screen


## How to test it
- Open app with eligible safe
- step to claiming screen
- observe new helper text below claiming button

## Screenshots
![gnosis-safe io_app_rin_0x979774d85274A5F63C85786aC4Fa54B9A4f391c2_apps_appUrl=http___localhost_3000_safe-claiming-app_](https://user-images.githubusercontent.com/2670790/190458856-7e1e6e7b-b55a-4fed-8fbd-5e7c52f3fb28.png)
