### PR TITLE
feat(trx builder simulation): Disable Trx Builder simulator for Astar and Velas networks

### DIFF
--- a/apps/tx-builder/src/lib/simulation/simulation.ts
+++ b/apps/tx-builder/src/lib/simulation/simulation.ts
@@ -21,6 +21,8 @@ const NON_SUPPORTED_CHAINS = [
   '73799',
   // Aurora
   '1313161554',
+  // Astar
+  '529',
 ]
 
 const isSimulationSupported = (chainId: string) => !NON_SUPPORTED_CHAINS.includes(chainId)

--- a/apps/tx-builder/src/lib/simulation/simulation.ts
+++ b/apps/tx-builder/src/lib/simulation/simulation.ts
@@ -23,6 +23,8 @@ const NON_SUPPORTED_CHAINS = [
   '1313161554',
   // Astar
   '529',
+  // Velas
+  '106',
 ]
 
 const isSimulationSupported = (chainId: string) => !NON_SUPPORTED_CHAINS.includes(chainId)


### PR DESCRIPTION
Disable Trx Builder simulator for astar network

Astar is not planning to integrate with Tenderly; a pre-requisite for the trx builder simulations to work

<!--
Remember to create a title following the Conventional Commits guidelines. Examples for valid PR titles are:

fix: Some thing found in the repo
feat: Add some feature
refactor!: Make some refactor
feat(wallet-connect): Add some feature

Note that since PR titles only have a single line, you have to use the ! syntax for breaking changes.

For more examples, take a look at:
- https://www.conventionalcommits.org/en/v1.0.0
-->

## What it solves
Resolves #

## How this PR fixes it

## How to test it

## Screenshots
