### PR TITLE
fix(safe-claiming-app): amount calculation uses 30 sec buffer

### DIFF
--- a/apps/safe-claiming-app/src/hooks/__tests__/useAmounts.test.ts
+++ b/apps/safe-claiming-app/src/hooks/__tests__/useAmounts.test.ts
@@ -62,6 +62,17 @@ describe("useAmounts()", () => {
     ])
   })
 
+  it("vested amount is smaller than amount claimed", () => {
+    // vesting is just half vested but already more than half is claimed (10 more than half)
+    const vestingClaim: VestingClaim = createMockVesting(2, 1000, -1, 510)
+    const result = renderHook(() => useAmounts(vestingClaim))
+    // nothing is claimable and 490 are in vesting
+    expect(result.result.current).toEqual([
+      ethers.utils.parseEther("0").toString(),
+      ethers.utils.parseEther("490").toString(),
+    ])
+  })
+
   it("vesting did not start yet", () => {
     const vestingClaim: VestingClaim = createMockVesting(1, 1000, 1)
     const result = renderHook(() => useAmounts(vestingClaim))

--- a/apps/safe-claiming-app/src/hooks/__tests__/useAmounts.test.ts
+++ b/apps/safe-claiming-app/src/hooks/__tests__/useAmounts.test.ts
@@ -2,31 +2,12 @@ import { renderHook } from "@testing-library/react-hooks"
 import { ethers } from "ethers"
 import { act } from "react-dom/test-utils"
 import { VestingClaim } from "src/types/vestings"
+import { DESYNC_BUFFER } from "src/utils/vesting"
 import { useAmounts } from "../useAmounts"
-import * as web3 from "src/utils/getWeb3Provider"
-import { waitFor } from "@testing-library/react"
 
 const fakeNow = new Date()
 
 const ONE_WEEK = 7 * 24 * 60 * 60
-
-const SAFE_ADDRESS = "0x6a13e0280740cc5bd35eeee33b470b5bbb93df37"
-
-jest.mock("@gnosis.pm/safe-apps-react-sdk", () => {
-  const originalModule = jest.requireActual("@gnosis.pm/safe-apps-react-sdk")
-  return {
-    __esModule: true,
-    // We require some of the enums/types from the original module
-    ...originalModule,
-    useSafeAppsSDK: () => ({
-      safe: {
-        safeAddress: "0x6a13E0280740CC5bd35eeee33B470b5bBb93dF37",
-        chainId: 4,
-      },
-      sdk: undefined,
-    }),
-  }
-})
 
 const createMockVesting = (
   durationWeeks: number,
@@ -49,12 +30,13 @@ const createMockVesting = (
     contract: ethers.utils.hexZeroPad("0x2", 20),
     tag: "user",
     startDate:
-      Math.floor(fakeNow.getTime() / 1000) + ONE_WEEK * vestingStartDiffInWeeks,
+      Math.floor(fakeNow.getTime() / 1000) -
+      DESYNC_BUFFER +
+      ONE_WEEK * vestingStartDiffInWeeks,
   }
 }
 
 describe("useAmounts()", () => {
-  let mockBlock: jest.Mock
   beforeAll(() => {
     jest.useFakeTimers()
   })
@@ -64,148 +46,104 @@ describe("useAmounts()", () => {
   })
 
   beforeEach(() => {
-    mockBlock = jest.fn()
-    jest.spyOn(web3, "getWeb3Provider").mockImplementation(
-      () =>
-        ({
-          getBlock: mockBlock,
-        } as any)
-    )
-    mockBlock.mockImplementationOnce(() =>
-      Promise.resolve({
-        timestamp: Math.floor(fakeNow.getTime() / 1000),
-      })
-    )
+    jest.setSystemTime(fakeNow)
   })
-
   it("should return 0 without vesting claim", () => {
     const result = renderHook(() => useAmounts(null))
     expect(result.result.current).toEqual(["0", "0"])
   })
 
-  it("fully vested amount", async () => {
+  it("fully vested amount", () => {
     const vestingClaim: VestingClaim = createMockVesting(1, 1000, -1)
     const result = renderHook(() => useAmounts(vestingClaim))
-    await waitFor(() => {
-      expect(result.result.current).toEqual([
-        ethers.utils.parseEther("1000").toString(),
-        "0",
-      ])
-    })
+    expect(result.result.current).toEqual([
+      ethers.utils.parseEther("1000").toString(),
+      "0",
+    ])
   })
 
-  it("vesting did not start yet", async () => {
+  it("vesting did not start yet", () => {
     const vestingClaim: VestingClaim = createMockVesting(1, 1000, 1)
     const result = renderHook(() => useAmounts(vestingClaim))
-    await waitFor(() => {
-      expect(result.result.current).toEqual([
-        "0",
-        ethers.utils.parseEther("1000").toString(),
-      ])
-    })
+    expect(result.result.current).toEqual([
+      "0",
+      ethers.utils.parseEther("1000").toString(),
+    ])
   })
 
-  it("vesting fully vested and fully claimed", async () => {
+  it("vesting fully vested and fully claimed", () => {
     const vestingClaim: VestingClaim = createMockVesting(1, 1000, -1, 1000)
     const result = renderHook(() => useAmounts(vestingClaim))
-    await waitFor(() => {
-      expect(result.result.current).toEqual([
-        ethers.utils.parseEther("0").toString(),
-        "0",
-      ])
-    })
+    expect(result.result.current).toEqual([
+      ethers.utils.parseEther("0").toString(),
+      "0",
+    ])
   })
 
-  it("vesting fully vested and partly claimed", async () => {
+  it("vesting fully vested and partly claimed", () => {
     const vestingClaim: VestingClaim = createMockVesting(1, 1000, -1, 500)
     const result = renderHook(() => useAmounts(vestingClaim))
-    await waitFor(() => {
-      expect(result.result.current).toEqual([
-        ethers.utils.parseEther("500").toString(),
-        "0",
-      ])
-    })
+    expect(result.result.current).toEqual([
+      ethers.utils.parseEther("500").toString(),
+      "0",
+    ])
   })
 
-  it("vesting half vested", async () => {
+  it("vesting half vested", () => {
     const vestingClaim: VestingClaim = createMockVesting(2, 1000, -1)
     const result = renderHook(() => useAmounts(vestingClaim))
-    await waitFor(() => {
-      expect(result.result.current).toEqual([
-        ethers.utils.parseEther("500").toString(),
-        ethers.utils.parseEther("500").toString(),
-      ])
-    })
+    expect(result.result.current).toEqual([
+      ethers.utils.parseEther("500").toString(),
+      ethers.utils.parseEther("500").toString(),
+    ])
   })
 
-  it("vesting half vested and quarter claimed", async () => {
+  it("vesting half vested and quarter claimed", () => {
     const vestingClaim: VestingClaim = createMockVesting(2, 1000, -1, 250)
     const result = renderHook(() => useAmounts(vestingClaim))
-    await waitFor(() => {
-      expect(result.result.current).toEqual([
-        ethers.utils.parseEther("250").toString(),
-        ethers.utils.parseEther("500").toString(),
-      ])
-    })
+    expect(result.result.current).toEqual([
+      ethers.utils.parseEther("250").toString(),
+      ethers.utils.parseEther("500").toString(),
+    ])
   })
 
-  it("vesting half vested and quarter claimed", async () => {
+  it("vesting half vested and quarter claimed", () => {
     const vestingClaim: VestingClaim = createMockVesting(2, 1000, -1, 250)
     const result = renderHook(() => useAmounts(vestingClaim))
-    await waitFor(() => {
-      expect(result.result.current).toEqual([
-        ethers.utils.parseEther("250").toString(),
-        ethers.utils.parseEther("500").toString(),
-      ])
-    })
+    expect(result.result.current).toEqual([
+      ethers.utils.parseEther("250").toString(),
+      ethers.utils.parseEther("500").toString(),
+    ])
   })
 
-  it("test polling and updating of vesting", async () => {
+  it("test polling and updating of vesting", () => {
     // vests 1 token per second
     const vestingClaim = createMockVesting(1, ONE_WEEK, 0)
     const result = renderHook(() => useAmounts(vestingClaim))
     // Initially nothing is vested and 1000 are in vesting
-    await waitFor(() => {
-      expect(result.result.current).toEqual([
-        ethers.utils.parseEther("0").toString(),
-        ethers.utils.parseEther(ONE_WEEK.toString()).toString(),
-      ])
-    })
-
-    // mock new block-timestamp
-    mockBlock.mockImplementation(() =>
-      Promise.resolve({
-        timestamp: Math.floor(fakeNow.getTime() / 1000) + 10,
-      })
-    )
+    expect(result.result.current).toEqual([
+      ethers.utils.parseEther("0").toString(),
+      ethers.utils.parseEther(ONE_WEEK.toString()).toString(),
+    ])
 
     // advance to next polling
     act(() => {
       jest.advanceTimersByTime(10_000)
     })
 
-    await waitFor(() => {
-      expect(result.result.current).toEqual([
-        ethers.utils.parseEther("10").toString(),
-        ethers.utils.parseEther((ONE_WEEK - 10).toString()).toString(),
-      ])
-    })
+    expect(result.result.current).toEqual([
+      ethers.utils.parseEther("10").toString(),
+      ethers.utils.parseEther((ONE_WEEK - 10).toString()).toString(),
+    ])
 
-    mockBlock.mockImplementation(() =>
-      Promise.resolve({
-        timestamp: Math.floor(fakeNow.getTime() / 1000) + 100,
-      })
-    )
     // Poll 9 more times
     act(() => {
       jest.advanceTimersByTime(90_000)
     })
 
-    await waitFor(() => {
-      expect(result.result.current).toEqual([
-        ethers.utils.parseEther("100").toString(),
-        ethers.utils.parseEther((ONE_WEEK - 100).toString()).toString(),
-      ])
-    })
+    expect(result.result.current).toEqual([
+      ethers.utils.parseEther("100").toString(),
+      ethers.utils.parseEther((ONE_WEEK - 100).toString()).toString(),
+    ])
   })
 })

--- a/apps/safe-claiming-app/src/hooks/useAmounts.ts
+++ b/apps/safe-claiming-app/src/hooks/useAmounts.ts
@@ -16,11 +16,18 @@ export const useAmounts = (
           return
         }
         const totalAmount = vestingClaim ? vestingClaim.amount : "0"
-        const vestedAmount = vestingClaim
+        let vestedAmount = vestingClaim
           ? calculateVestedAmount(vestingClaim)
           : "0"
+        const amountClaimed = vestingClaim?.amountClaimed || "0"
+
+        // If a user just claimed it can happen, that the amountClaimed is > vestedAmount for ~30s
+        if (BigNumber.from(vestedAmount).lt(amountClaimed)) {
+          vestedAmount = amountClaimed
+        }
+
         const newClaimableAmount = BigNumber.from(vestedAmount)
-          .sub(BigNumber.from(vestingClaim?.amountClaimed || "0"))
+          .sub(BigNumber.from(amountClaimed))
           .toString()
 
         const newAmountInVesting = BigNumber.from(totalAmount)

--- a/apps/safe-claiming-app/src/hooks/useAmounts.ts
+++ b/apps/safe-claiming-app/src/hooks/useAmounts.ts
@@ -1,8 +1,6 @@
-import { useSafeAppsSDK } from "@gnosis.pm/safe-apps-react-sdk"
 import { BigNumber } from "ethers"
 import { useEffect, useState } from "react"
 import { VestingClaim } from "src/types/vestings"
-import { getWeb3Provider } from "src/utils/getWeb3Provider"
 import { calculateVestedAmount } from "src/utils/vesting"
 
 export const useAmounts = (
@@ -10,19 +8,16 @@ export const useAmounts = (
 ): [string, string] => {
   const [claimableAmount, setClaimableAmount] = useState("0")
   const [amountInVesting, setAmountInVesting] = useState("0")
-  const { safe, sdk } = useSafeAppsSDK()
 
   useEffect(() => {
-    const refreshAmount = async () => {
+    const refreshAmount = () => {
       try {
-        const web3Provider = getWeb3Provider(safe, sdk)
-
-        // get timestamp from latest block
-        const latestBlock = await web3Provider.getBlock("latest")
-        const blockTimestamp = latestBlock.timestamp
+        if (!vestingClaim) {
+          return
+        }
         const totalAmount = vestingClaim ? vestingClaim.amount : "0"
         const vestedAmount = vestingClaim
-          ? calculateVestedAmount(vestingClaim, blockTimestamp)
+          ? calculateVestedAmount(vestingClaim)
           : "0"
         const newClaimableAmount = BigNumber.from(vestedAmount)
           .sub(BigNumber.from(vestingClaim?.amountClaimed || "0"))
@@ -48,7 +43,7 @@ export const useAmounts = (
     const refreshAmountInterval = window.setInterval(refreshAmount, 10000)
 
     return () => window.clearInterval(refreshAmountInterval)
-  }, [safe, sdk, vestingClaim])
+  }, [vestingClaim])
 
   return [claimableAmount, amountInVesting]
 }


### PR DESCRIPTION
## What it solves
The block timestamp still caused the same issue in rare cases. The 30 second desync buffer seems more stable.

## How this PR fixes it
Substracts fixed 30 seconds from the current timestamp before calculating the vested amount

## How to test it
- open app for safe with user and ecosystem allocation
- use custom claim amount > user allocation
- the gas estimation should not fail
