### PR TITLE
fix(safe-claiming-app): validate custom delegation address

### DIFF
--- a/apps/safe-claiming-app/src/components/steps/Delegate/index.tsx
+++ b/apps/safe-claiming-app/src/components/steps/Delegate/index.tsx
@@ -103,7 +103,9 @@ const Delegate = ({
   }
 
   const enableNextButton =
-    (isCustomDelegation && Boolean(customEnsResult)) ||
+    (isCustomDelegation &&
+      Boolean(customEnsResult) &&
+      !Boolean(customAddressError)) ||
     (!isCustomDelegation && Boolean(chosenDelegate))
 
   return (
@@ -155,8 +157,8 @@ const Delegate = ({
               >
                 <Grid item xs={12}>
                   <Typography mb={1}>
-                    You can select yourself or any other person to be a
-                    delegate.
+                    The wallet address can belong to any person but you cannot
+                    delegate to your own Safe.
                   </Typography>
                   <TextField
                     fullWidth

--- a/apps/safe-claiming-app/src/hooks/__tests__/useEnsResolution.test.tsx
+++ b/apps/safe-claiming-app/src/hooks/__tests__/useEnsResolution.test.tsx
@@ -2,7 +2,6 @@ import { renderHook, act } from "@testing-library/react-hooks"
 import { waitFor } from "@testing-library/react"
 import { useEnsResolution } from "src/hooks/useEnsResolution"
 import { getWeb3Provider } from "src/utils/getWeb3Provider"
-import * as utils from "src/utils/addresses"
 
 const mockWeb3Provider = {
   resolveName: jest.fn(() => Promise.reject("resolveName")),
@@ -15,7 +14,10 @@ jest.mock("@gnosis.pm/safe-apps-react-sdk", () => {
     // We require some of the enums/types from the original module
     ...originalModule,
     useSafeAppsSDK: () => ({
-      safe: { chainId: 1 },
+      safe: {
+        chainId: 1,
+        safeAddress: "0x2000000000000000000000000000000000000000",
+      },
       sdk: undefined,
     }),
   }
@@ -27,7 +29,6 @@ jest.mock("src/utils/getWeb3Provider", () => ({
 
 describe("useEnsResolution()", () => {
   const web3Provider = getWeb3Provider(undefined as never, undefined as never)
-  jest.spyOn(utils, "sameAddress").mockImplementation(() => false)
 
   afterAll(() => {
     jest.unmock("src/utils/getWeb3Provider")
@@ -99,7 +100,7 @@ describe("useEnsResolution()", () => {
     expect(web3Provider.resolveName).not.toHaveBeenCalled()
   })
 
-  it("should return immediately for empty strings and not trigger ens resolution ", async () => {
+  it("should return immediately for empty strings and not trigger ens resolution", async () => {
     web3Provider.resolveName = jest.fn()
     jest.useFakeTimers()
     const { result } = renderHook(() => useEnsResolution(""))
@@ -316,9 +317,8 @@ describe("useEnsResolution()", () => {
   })
 
   it("should set error if resolved address is the same as the current safe address", async () => {
-    const resolvedAddress = "0x1000000000000000000000000000000000000000"
+    const resolvedAddress = "0x2000000000000000000000000000000000000000"
     web3Provider.resolveName = jest.fn(() => Promise.resolve(resolvedAddress))
-    jest.spyOn(utils, "sameAddress").mockImplementation(() => true)
     jest.useFakeTimers()
     const { result } = renderHook(() => useEnsResolution("test.eth"))
 
@@ -342,8 +342,7 @@ describe("useEnsResolution()", () => {
   })
 
   it("should set error if typed address is the same as the current safe address", async () => {
-    const resolvedAddress = "0x1000000000000000000000000000000000000000"
-    jest.spyOn(utils, "sameAddress").mockImplementation(() => true)
+    const resolvedAddress = "0x2000000000000000000000000000000000000000"
     jest.useFakeTimers()
     const { result } = renderHook(() => useEnsResolution(resolvedAddress))
 

--- a/apps/safe-claiming-app/src/hooks/useEnsResolution.ts
+++ b/apps/safe-claiming-app/src/hooks/useEnsResolution.ts
@@ -43,10 +43,14 @@ export const useEnsResolution = (
     }
 
     if (ethers.utils.isAddress(customAddress)) {
+      const error =
+        customAddress === safe.safeAddress
+          ? "You can't delegate to your own Safe"
+          : undefined
       // No need to resolve via ENS
       setEnsResult({ address: ethers.utils.getAddress(customAddress) })
       setEnsLoading(false)
-      setError(undefined)
+      setError(error)
       return
     }
 
@@ -57,6 +61,11 @@ export const useEnsResolution = (
         const resolvedName = await web3Provider.resolveName(customAddress)
 
         if (resolvedName !== null && ethers.utils.isAddress(resolvedName)) {
+          if (resolvedName === safe.safeAddress) {
+            isMounted && setEnsResult(undefined)
+            isMounted && setError("You can't delegate to your own Safe")
+            return
+          }
           isMounted &&
             setEnsResult({
               address: resolvedName,
@@ -90,7 +99,7 @@ export const useEnsResolution = (
       isMounted = false
     }
     // If we add the ensTimeout it will always trigger
-  }, [chainPrefix, debounce, manualAddress, web3Provider])
+  }, [chainPrefix, debounce, manualAddress, safe.safeAddress, web3Provider])
 
   return [ensResult, error, ensLoading]
 }

--- a/apps/safe-claiming-app/src/hooks/useEnsResolution.ts
+++ b/apps/safe-claiming-app/src/hooks/useEnsResolution.ts
@@ -1,7 +1,7 @@
 import { useSafeAppsSDK } from "@gnosis.pm/safe-apps-react-sdk"
 import { ethers } from "ethers"
 import { useEffect, useMemo, useState } from "react"
-import { parsePrefixedAddress } from "src/utils/addresses"
+import { parsePrefixedAddress, sameAddress } from "src/utils/addresses"
 import { getWeb3Provider } from "src/utils/getWeb3Provider"
 
 type ENSResult = {
@@ -43,10 +43,9 @@ export const useEnsResolution = (
     }
 
     if (ethers.utils.isAddress(customAddress)) {
-      const error =
-        customAddress === safe.safeAddress
-          ? "You can't delegate to your own Safe"
-          : undefined
+      const error = sameAddress(customAddress, safe.safeAddress)
+        ? "You can't delegate to your own Safe"
+        : undefined
       // No need to resolve via ENS
       setEnsResult({ address: ethers.utils.getAddress(customAddress) })
       setEnsLoading(false)
@@ -61,7 +60,7 @@ export const useEnsResolution = (
         const resolvedName = await web3Provider.resolveName(customAddress)
 
         if (resolvedName !== null && ethers.utils.isAddress(resolvedName)) {
-          if (resolvedName === safe.safeAddress) {
+          if (sameAddress(resolvedName, safe.safeAddress)) {
             isMounted && setEnsResult(undefined)
             isMounted && setError("You can't delegate to your own Safe")
             return

--- a/apps/safe-claiming-app/src/hooks/useEnsResolution.ts
+++ b/apps/safe-claiming-app/src/hooks/useEnsResolution.ts
@@ -63,13 +63,13 @@ export const useEnsResolution = (
           if (sameAddress(resolvedName, safe.safeAddress)) {
             isMounted && setEnsResult(undefined)
             isMounted && setError("You can't delegate to your own Safe")
-            return
+          } else {
+            isMounted &&
+              setEnsResult({
+                address: resolvedName,
+                ens: customAddress,
+              })
           }
-          isMounted &&
-            setEnsResult({
-              address: resolvedName,
-              ens: customAddress,
-            })
         } else {
           isMounted && setEnsResult(undefined)
           isMounted && setError("Invalid address / ENS name")


### PR DESCRIPTION
## What it solves
Resolves #540 

## How this PR fixes it

- Updates the input field text description
- Validates that the address is not the same as the current safe address

## How to test it

1. Open a safe that is elligible for the airdrop
2. Navigate to the custom delegate screen
3. Input the current safe address
4. Observe a validation error and the next button is disabled
5. Input an ENS that resolves to the current safe address
6. Observe a validation error and the next button is disabled 

## Screenshots
<img width="688" alt="Screenshot 2022-10-04 at 11 31 55" src="https://user-images.githubusercontent.com/5880855/193785853-08bc9031-1883-4f3f-abfc-dff6bec9da24.png">
