### PR TITLE
fix(e2e): Remove `push` workflow dispatch

### DIFF
--- a/.github/workflows/safe-apps-check.yml
+++ b/.github/workflows/safe-apps-check.yml
@@ -1,6 +1,5 @@
 name: Test Safe Apps
 on:
-  push:
   workflow_dispatch:
     inputs:
       baseUrl:


### PR DESCRIPTION
## What it solves
Remove wrong `push` workflow dispatch remaining from testing
