### PR TITLE
feat(tx-builder): Add Transaction builder analytics

### DIFF
--- a/apps/tx-builder/src/lib/analytics.ts
+++ b/apps/tx-builder/src/lib/analytics.ts
@@ -1,0 +1,13 @@
+const SAFE_APPS_ANALYTIC_CATEGORY = 'safe-apps-analytics'
+
+export const trackSafeAppEvent = (action: string, label?: string) => {
+  window.parent.postMessage(
+    {
+      category: SAFE_APPS_ANALYTIC_CATEGORY,
+      action,
+      label,
+      safeAppName: 'Transaction Builder',
+    },
+    '*',
+  )
+}

--- a/apps/tx-builder/src/lib/analytics.ts
+++ b/apps/tx-builder/src/lib/analytics.ts
@@ -1,9 +1,9 @@
-const SAFE_APPS_ANALYTIC_CATEGORY = 'safe-apps-analytics'
+const SAFE_APPS_ANALYTICS_CATEGORY = 'safe-apps-analytics'
 
 export const trackSafeAppEvent = (action: string, label?: string) => {
   window.parent.postMessage(
     {
-      category: SAFE_APPS_ANALYTIC_CATEGORY,
+      category: SAFE_APPS_ANALYTICS_CATEGORY,
       action,
       label,
       safeAppName: 'Transaction Builder',

--- a/apps/tx-builder/src/lib/storage.ts
+++ b/apps/tx-builder/src/lib/storage.ts
@@ -1,5 +1,6 @@
 import localforage from 'localforage'
 import { BatchFile } from '../typings/models'
+import { trackSafeAppEvent } from './analytics'
 import { stringifyReplacer } from './checksum'
 
 localforage.config({
@@ -13,6 +14,8 @@ const saveBatch = async (batchFile: BatchFile): Promise<{ id: string; batchFile:
   const id = uuidv4()
   try {
     await localforage.setItem(id, batchFile)
+
+    trackSafeAppEvent('Saved batch', batchFile.transactions.length.toString())
   } catch (error) {
     console.error(error)
   }
@@ -26,6 +29,8 @@ const saveBatch = async (batchFile: BatchFile): Promise<{ id: string; batchFile:
 const removeBatch = async (batchId: string): Promise<void> => {
   try {
     await localforage.removeItem(batchId)
+
+    trackSafeAppEvent('Remove batch')
   } catch (error) {
     console.error(error)
   }
@@ -34,6 +39,8 @@ const removeBatch = async (batchId: string): Promise<void> => {
 const updateBatch = async (batchId: string, batchFile: BatchFile): Promise<void> => {
   try {
     await localforage.setItem(batchId, batchFile)
+
+    trackSafeAppEvent('Update batch')
   } catch (error) {
     console.error(error)
   }
@@ -76,6 +83,8 @@ const downloadObjectAsJson = (batchFile: BatchFile) => {
 
 const downloadBatch = async (batchFile: BatchFile) => {
   downloadObjectAsJson(batchFile)
+
+  trackSafeAppEvent('Download batch')
 }
 
 const importBatch = async (file: File): Promise<BatchFile> => {
@@ -85,6 +94,8 @@ const importBatch = async (file: File): Promise<BatchFile> => {
     reader.onload = () => {
       const batchFile: BatchFile = JSON.parse(reader.result as string)
       resolve(batchFile)
+
+      trackSafeAppEvent('Import batch')
     }
   })
 }

--- a/apps/tx-builder/src/store/transactionsContext.tsx
+++ b/apps/tx-builder/src/store/transactionsContext.tsx
@@ -1,4 +1,5 @@
 import { createContext, useCallback, useContext, useState } from 'react'
+import { trackSafeAppEvent } from '../lib/analytics'
 import { ProposedTransaction } from '../typings/models'
 import { useNetwork } from './networkContext'
 
@@ -50,6 +51,8 @@ const TransactionsProvider: React.FC = ({ children }) => {
     await sdk.txs.send({
       txs: transactions.map(transaction => transaction.raw),
     })
+
+    trackSafeAppEvent('Submit transactions confirmed')
   }, [sdk.txs, transactions])
 
   const reorderTransactions = useCallback((sourceIndex, destinationIndex) => {


### PR DESCRIPTION
## What it solves
Resolves https://github.com/safe-global/web-core/issues/1126

## How this PR fixes it
We are adding some analytics to the Transaction Builder

## How to test it
Check the following Analytics are being sent using the correct [web-core version](https://github.com/safe-global/web-core/pull/1066)

1) 'Submit transactions confirmed' after a transaction is confirmed
2) 'Saved batch' after saving a batch
3) 'Remove batch' after removing a batch
4) 'Update batch' after updating a batch
5) 'Download batch' after pressing the download batch button
6) 'Import batch' after dragging or opening a file containing a batch

