### PR TITLE
fix(safe-claiming-app): claiming widget not loading in Firefox

### DIFF
--- a/apps/safe-claiming-app/src/config/constants.ts
+++ b/apps/safe-claiming-app/src/config/constants.ts
@@ -19,6 +19,10 @@ export const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000"
 
 const isProdEnv = process.env.NODE_ENV === "production"
 
+export const WEB_APP_URL = isProdEnv
+  ? "https://app.safe.global"
+  : "https://safe-web-core.dev.5afe.dev"
+
 export const CLAIMING_APP_URL = isProdEnv
   ? "https://apps.gnosis-safe.io/safe-claiming-app"
   : "https://safe-apps.dev.5afe.dev/safe-claiming-app"

--- a/apps/safe-claiming-app/src/widgets/ClaimingWidget.tsx
+++ b/apps/safe-claiming-app/src/widgets/ClaimingWidget.tsx
@@ -13,7 +13,7 @@ import { BigNumber, ethers } from "ethers"
 import { useMemo } from "react"
 import { ReactComponent as SafeIcon } from "src/assets/images/safe-token.svg"
 import { SelectedDelegate } from "src/components/steps/Claim/SelectedDelegate"
-import { CLAIMING_APP_URL } from "src/config/constants"
+import { CLAIMING_APP_URL, WEB_APP_URL } from "src/config/constants"
 import { useAirdropFile } from "src/hooks/useAirdropFile"
 import { useDelegate } from "src/hooks/useDelegate"
 import { useDelegatesFile } from "src/hooks/useDelegatesFile"
@@ -108,7 +108,7 @@ const ClaimingWidget = () => {
       BigNumber.from(ecosystemVesting?.amount || 0).gt(0))
 
   const currentChainPrefix = safe.chainId === 1 ? "eth" : "gor"
-  const claimingSafeAppUrl = `${window.location.ancestorOrigins[0]}/apps?safe=${currentChainPrefix}:${safe.safeAddress}&appUrl=${CLAIMING_APP_URL}`
+  const claimingSafeAppUrl = `${WEB_APP_URL}/apps?safe=${currentChainPrefix}:${safe.safeAddress}&appUrl=${CLAIMING_APP_URL}`
 
   const ctaWidget = (
     <>

--- a/apps/safe-claiming-app/src/widgets/SnapshotWidget.tsx
+++ b/apps/safe-claiming-app/src/widgets/SnapshotWidget.tsx
@@ -91,7 +91,7 @@ const SnapshotProposals = ({
         >
           {_getProposalNumber(proposal.title)}
         </StyledNumber>
-        <Box gridArea="title">
+        <Box gridArea="title" overflow="hidden">
           <Typography
             overflow="hidden"
             color="text.primary"


### PR DESCRIPTION
<!--
Remember to create a title following the Conventional Commits guidelines. Examples for valid PR titles are:

fix: Some thing found in the repo
feat: Add some feature
refactor!: Make some refactor
feat(wallet-connect): Add some feature

Note that since PR titles only have a single line, you have to use the ! syntax for breaking changes.

For more examples, take a look at:
- https://www.conventionalcommits.org/en/v1.0.0
-->

## What it solves
Resolves Firefox issues reported in https://github.com/safe-global/web-core/pull/1149#pullrequestreview-1189859400
![Firefox widgets issues](https://user-images.githubusercontent.com/32431609/203367710-825f54da-1f60-4378-a472-6e735f495752.gif)

## How this PR fixes it
(Truncate not working) - Add `overflow: hidden` to the text element parent
(Claiming widget not loading) - `location.ancestorOrigins` does not work cross browser so I've created a constant to switch between staging and production domains

## How to test it
Navigate to `/home` in Firefox.
Snapshot titles should truncate.
Claiming widget should load
Claiming button takes you to the main Claiming app

## Screenshots
![Screenshot 2022-11-22 at 17 32 26](https://user-images.githubusercontent.com/32431609/203369337-d3f7840e-40db-4604-99bc-30826296a838.png)
