### PR TITLE
feat: read dark mode from search query

### DIFF
--- a/apps/safe-claiming-app/src/hooks/useDarkMode.ts
+++ b/apps/safe-claiming-app/src/hooks/useDarkMode.ts
@@ -16,7 +16,7 @@ export const useDarkMode = (): boolean => {
     const urlDarkMode = urlParams.get("theme")
 
     setIsDarkMode(urlDarkMode === "dark" || isSystemDarkMode())
-  }, [location.hash, location.search])
+  }, [location.search])
 
   return isDarkMode
 }

--- a/apps/safe-claiming-app/src/hooks/useDarkMode.ts
+++ b/apps/safe-claiming-app/src/hooks/useDarkMode.ts
@@ -12,8 +12,11 @@ export const useDarkMode = (): boolean => {
   const [isDarkMode, setIsDarkMode] = useState<boolean>(false)
 
   useEffect(() => {
-    setIsDarkMode(location.hash.endsWith("+dark") || isSystemDarkMode())
-  }, [location.hash])
+    const urlParams = new URLSearchParams(location.search)
+    const urlDarkMode = urlParams.get("theme")
+
+    setIsDarkMode(urlDarkMode === "dark" || isSystemDarkMode())
+  }, [location.hash, location.search])
 
   return isDarkMode
 }


### PR DESCRIPTION
<!--
Remember to create a title following the Conventional Commits guidelines. Examples for valid PR titles are:

fix: Some thing found in the repo
feat: Add some feature
refactor!: Make some refactor
feat(wallet-connect): Add some feature

Note that since PR titles only have a single line, you have to use the ! syntax for breaking changes.

For more examples, take a look at:
- https://www.conventionalcommits.org/en/v1.0.0
-->

## What it solves
Reads the dark mode passed to the Claiming app through a search param instead of `+dark` in the location hash.

## How this PR fixes it
Reads the dark mode from `window.location.search`

## How to test it
https://github.com/safe-global/web-core/pull/1219 can be run locally to test this change
