### PR TITLE
fix(safe-claiming-app): Fixes multiple issues with government widgets

### DIFF
--- a/apps/safe-claiming-app/src/components/AppSwitch.tsx
+++ b/apps/safe-claiming-app/src/components/AppSwitch.tsx
@@ -1,7 +1,8 @@
 import App from "src/App"
 import { useLightDarkTheme } from "src/hooks/useDarkMode"
-import { ThemeProvider } from "@mui/material"
+import { Box, CircularProgress, ThemeProvider } from "@mui/material"
 import Widget from "src/widgets/Widget"
+import SafeProvider from "@gnosis.pm/safe-apps-react-sdk"
 
 export const AppSwitch = () => {
   const theme = useLightDarkTheme()
@@ -9,7 +10,23 @@ export const AppSwitch = () => {
 
   return (
     <ThemeProvider theme={theme}>
-      {widgetId === "#widget" ? <Widget /> : <App />}
+      <SafeProvider
+        loader={
+          <Box
+            display="flex"
+            height="100vh"
+            justifyContent="center"
+            alignItems="center"
+            sx={{
+              backgroundColor: ({ palette }) => palette.background.default,
+            }}
+          >
+            <CircularProgress />
+          </Box>
+        }
+      >
+        {widgetId === "#widget" ? <Widget /> : <App />}
+      </SafeProvider>
     </ThemeProvider>
   )
 }

--- a/apps/safe-claiming-app/src/config/constants.ts
+++ b/apps/safe-claiming-app/src/config/constants.ts
@@ -40,7 +40,7 @@ export const GUARDIANS_IMAGE_URL = `${CLAIMING_DATA_URL}/guardians/images/`
 
 export const VESTING_URL = `${CLAIMING_DATA_URL}/allocations/`
 
-export const FORUM_URL = "https://forum.gnosis-safe.io"
+export const FORUM_URL = "https://forum.safe.global"
 
 export const DISCORD_URL = "https://discord.gg/gXK3gt8w3D"
 

--- a/apps/safe-claiming-app/src/hooks/useSafeSnapshot.ts
+++ b/apps/safe-claiming-app/src/hooks/useSafeSnapshot.ts
@@ -1,3 +1,5 @@
+import { useSafeAppsSDK } from "@gnosis.pm/safe-apps-react-sdk"
+import { CHAIN_CONSTANTS } from "src/config/constants"
 import useAsync, { type AsyncResult } from "src/hooks/useAsync"
 
 type ShapshotProposalVars = {
@@ -63,8 +65,11 @@ const getSnapshot = async (
   return data.proposals
 }
 
-const getSafeSnapshot = (amount: number): Promise<SnapshotProposal[]> => {
-  const SNAPSHOT_SPACE = "safe.eth"
+const getSafeSnapshot = (
+  amount: number,
+  chainId: number
+): Promise<SnapshotProposal[]> => {
+  const SNAPSHOT_SPACE = CHAIN_CONSTANTS[chainId].DELEGATE_ID
 
   return getSnapshot({
     space: SNAPSHOT_SPACE,
@@ -76,7 +81,8 @@ const getSafeSnapshot = (amount: number): Promise<SnapshotProposal[]> => {
 }
 
 const useSafeSnapshot = (amount: number): AsyncResult<SnapshotProposal[]> => {
-  return useAsync(() => getSafeSnapshot(amount), [])
+  const { safe } = useSafeAppsSDK()
+  return useAsync(() => getSafeSnapshot(amount, safe.chainId), [])
 }
 
 export default useSafeSnapshot

--- a/apps/safe-claiming-app/src/hooks/useSafeSnapshot.ts
+++ b/apps/safe-claiming-app/src/hooks/useSafeSnapshot.ts
@@ -1,6 +1,5 @@
-import { useSafeAppsSDK } from "@gnosis.pm/safe-apps-react-sdk"
-import { CHAIN_CONSTANTS } from "src/config/constants"
 import useAsync, { type AsyncResult } from "src/hooks/useAsync"
+import { useSafeSnapshotSpace } from "./useSnapshotSpace"
 
 type ShapshotProposalVars = {
   space: string
@@ -67,12 +66,10 @@ const getSnapshot = async (
 
 const getSafeSnapshot = (
   amount: number,
-  chainId: number
+  space: string
 ): Promise<SnapshotProposal[]> => {
-  const SNAPSHOT_SPACE = CHAIN_CONSTANTS[chainId].DELEGATE_ID
-
   return getSnapshot({
-    space: SNAPSHOT_SPACE,
+    space,
     first: amount,
     skip: 0,
     orderBy: "created",
@@ -81,8 +78,8 @@ const getSafeSnapshot = (
 }
 
 const useSafeSnapshot = (amount: number): AsyncResult<SnapshotProposal[]> => {
-  const { safe } = useSafeAppsSDK()
-  return useAsync(() => getSafeSnapshot(amount, safe.chainId), [])
+  const snapshotSpace = useSafeSnapshotSpace()
+  return useAsync(() => getSafeSnapshot(amount, snapshotSpace), [snapshotSpace])
 }
 
 export default useSafeSnapshot

--- a/apps/safe-claiming-app/src/hooks/useSnapshotSpace.ts
+++ b/apps/safe-claiming-app/src/hooks/useSnapshotSpace.ts
@@ -1,0 +1,7 @@
+import { useSafeAppsSDK } from "@gnosis.pm/safe-apps-react-sdk"
+import { CHAIN_CONSTANTS } from "src/config/constants"
+
+export const useSafeSnapshotSpace = () => {
+  const { safe } = useSafeAppsSDK()
+  return CHAIN_CONSTANTS[safe.chainId]?.DELEGATE_ID
+}

--- a/apps/safe-claiming-app/src/index.tsx
+++ b/apps/safe-claiming-app/src/index.tsx
@@ -1,5 +1,4 @@
 import React from "react"
-import SafeProvider from "@gnosis.pm/safe-apps-react-sdk"
 import { CssBaseline, GlobalStyles } from "@mui/material"
 
 import { render } from "react-dom"
@@ -11,9 +10,7 @@ render(
   <React.StrictMode>
     <GlobalStyles styles={{ body: { overflow: "hidden" } }} />
     <CssBaseline />
-    <SafeProvider loader={<h1>Waiting for Safe...</h1>}>
-      <AppSwitch />
-    </SafeProvider>
+    <AppSwitch />
   </React.StrictMode>,
   container
 )

--- a/apps/safe-claiming-app/src/widgets/ClaimingWidget.tsx
+++ b/apps/safe-claiming-app/src/widgets/ClaimingWidget.tsx
@@ -1,4 +1,5 @@
 import { useSafeAppsSDK } from "@gnosis.pm/safe-apps-react-sdk"
+import { OpenInNewRounded } from "@mui/icons-material"
 import {
   Box,
   Button,
@@ -8,12 +9,18 @@ import {
   Link,
   Skeleton,
   Card,
+  styled,
 } from "@mui/material"
 import { BigNumber, ethers } from "ethers"
 import { useMemo } from "react"
 import { ReactComponent as SafeIcon } from "src/assets/images/safe-token.svg"
 import { SelectedDelegate } from "src/components/steps/Claim/SelectedDelegate"
-import { CLAIMING_APP_URL, WEB_APP_URL } from "src/config/constants"
+import {
+  CLAIMING_APP_URL,
+  DISCORD_URL,
+  FORUM_URL,
+  WEB_APP_URL,
+} from "src/config/constants"
 import { useAirdropFile } from "src/hooks/useAirdropFile"
 import { useDelegate } from "src/hooks/useDelegate"
 import { useDelegatesFile } from "src/hooks/useDelegatesFile"
@@ -41,6 +48,14 @@ const Subtitle = (props: TypographyProps) => (
     {props.children}
   </Typography>
 )
+
+const StyledExternalLink = styled(Link)`
+  display: inline-flex;
+  align-items: center;
+  font-weight: 700;
+  gap: 4px;
+  text-decoration: none;
+`
 
 const StyledButton = (props: ButtonProps) => (
   <Button
@@ -113,14 +128,43 @@ const ClaimingWidget = () => {
   const ctaWidget = (
     <>
       <div>
-        <Title>Become the part of Safe's future!</Title>
+        <Title>Become part of Safe's future</Title>
         <br />
         <Subtitle>
-          You will be able to buy $SAFE once the token transferability is
-          enabled.
+          Help us unlocking ownership for everyone by joining the discussions in
+          the{" "}
+          <StyledExternalLink
+            href={FORUM_URL}
+            rel="noreferrer noopener"
+            target="_blank"
+            variant="subtitle1"
+            textAlign="center"
+            fontSize="small"
+          >
+            SafeDAO Forum
+            <OpenInNewRounded
+              sx={{ width: "0.75em", height: "0.75em" }}
+              fontSize="small"
+            />
+          </StyledExternalLink>{" "}
+          and our
+          <StyledExternalLink
+            href={DISCORD_URL}
+            rel="noreferrer noopener"
+            target="_blank"
+            variant="subtitle1"
+            textAlign="center"
+            fontSize="small"
+          >
+            Discord
+            <OpenInNewRounded
+              sx={{ width: "0.75em", height: "0.75em" }}
+              fontSize="small"
+            />
+          </StyledExternalLink>
+          .
         </Subtitle>
       </div>
-      <StyledButton disabled>Buy Tokens</StyledButton>
     </>
   )
 
@@ -191,14 +235,20 @@ const ClaimingWidget = () => {
     balanceLoading
   if (onChainRequestsLoading) {
     return (
-      <Box height={`${WIDGET_HEIGHT}px`} sx={{ minWidth: "280px" }}>
+      <Box
+        height={`${WIDGET_HEIGHT}px`}
+        sx={{
+          minWidth: "300px",
+          maxWidth: "300px",
+        }}
+      >
         <Skeleton variant="rounded" width="100%" height="100%" />
       </Box>
     )
   }
 
   return (
-    <Card elevation={0} sx={{ minWidth: "280px" }}>
+    <Card elevation={0} sx={{ minWidth: "300px", maxWidth: "300px" }}>
       <SpaceContent sx={{ alignItems: "center" }}>
         {votingPower.eq(0) ? ctaWidget : votingPowerWidget}
       </SpaceContent>

--- a/apps/safe-claiming-app/src/widgets/ClaimingWidget.tsx
+++ b/apps/safe-claiming-app/src/widgets/ClaimingWidget.tsx
@@ -57,6 +57,27 @@ const StyledExternalLink = styled(Link)`
   text-decoration: none;
 `
 
+const ExternalLink = ({ url, label }: { url: string; label: string }) => {
+  return (
+    <StyledExternalLink
+      href={url}
+      rel="noreferrer noopener"
+      target="_blank"
+      variant="subtitle1"
+      textAlign="center"
+      fontSize="small"
+    >
+      {label}
+      <OpenInNewRounded
+        sx={{ width: "0.75em", height: "0.75em" }}
+        fontSize="small"
+      />
+    </StyledExternalLink>
+  )
+}
+
+const WIDGET_WIDTH = "300px"
+
 const StyledButton = (props: ButtonProps) => (
   <Button
     size="large"
@@ -131,38 +152,9 @@ const ClaimingWidget = () => {
         <Title>Become part of Safe's future</Title>
         <br />
         <Subtitle>
-          Help us unlocking ownership for everyone by joining the discussions in
-          the{" "}
-          <StyledExternalLink
-            href={FORUM_URL}
-            rel="noreferrer noopener"
-            target="_blank"
-            variant="subtitle1"
-            textAlign="center"
-            fontSize="small"
-          >
-            SafeDAO Forum
-            <OpenInNewRounded
-              sx={{ width: "0.75em", height: "0.75em" }}
-              fontSize="small"
-            />
-          </StyledExternalLink>{" "}
-          and our
-          <StyledExternalLink
-            href={DISCORD_URL}
-            rel="noreferrer noopener"
-            target="_blank"
-            variant="subtitle1"
-            textAlign="center"
-            fontSize="small"
-          >
-            Discord
-            <OpenInNewRounded
-              sx={{ width: "0.75em", height: "0.75em" }}
-              fontSize="small"
-            />
-          </StyledExternalLink>
-          .
+          Help us unlock ownership for everyone by joining the discussions on
+          the <ExternalLink url={FORUM_URL} label="SafeDAO Forum" /> and our{" "}
+          <ExternalLink url={DISCORD_URL} label="Discord" />.
         </Subtitle>
       </div>
     </>
@@ -238,8 +230,8 @@ const ClaimingWidget = () => {
       <Box
         height={`${WIDGET_HEIGHT}px`}
         sx={{
-          minWidth: "300px",
-          maxWidth: "300px",
+          minWidth: WIDGET_WIDTH,
+          maxWidth: WIDGET_WIDTH,
         }}
       >
         <Skeleton variant="rounded" width="100%" height="100%" />
@@ -248,7 +240,7 @@ const ClaimingWidget = () => {
   }
 
   return (
-    <Card elevation={0} sx={{ minWidth: "300px", maxWidth: "300px" }}>
+    <Card elevation={0} sx={{ minWidth: WIDGET_WIDTH, maxWidth: WIDGET_WIDTH }}>
       <SpaceContent sx={{ alignItems: "center" }}>
         {votingPower.eq(0) ? ctaWidget : votingPowerWidget}
       </SpaceContent>

--- a/apps/safe-claiming-app/src/widgets/SnapshotWidget.tsx
+++ b/apps/safe-claiming-app/src/widgets/SnapshotWidget.tsx
@@ -1,3 +1,4 @@
+import { useSafeAppsSDK } from "@gnosis.pm/safe-apps-react-sdk"
 import { OpenInNewRounded } from "@mui/icons-material"
 import {
   Box,
@@ -8,6 +9,7 @@ import {
   styled,
   Card,
 } from "@mui/material"
+import { CHAIN_CONSTANTS, FORUM_URL } from "src/config/constants"
 import useSafeSnapshot, {
   type SnapshotProposal,
 } from "src/hooks/useSafeSnapshot"
@@ -126,8 +128,10 @@ const SnapshotProposals = ({
 )
 
 const SnapshotWidget = () => {
-  const SNAPSHOT_LINK = "https://snapshot.org/#/safe.eth"
-  const FORUM_LINK = "https://forum.safe.global"
+  const { safe } = useSafeAppsSDK()
+  const snapshotSpace = CHAIN_CONSTANTS[safe.chainId]?.DELEGATE_ID
+
+  const SNAPSHOT_LINK = `https://snapshot.org/#/${snapshotSpace}`
   const PROPOSAL_AMOUNT = 3
 
   const [proposals, loading] = useSafeSnapshot(PROPOSAL_AMOUNT)
@@ -180,7 +184,7 @@ const SnapshotWidget = () => {
             View all <OpenInNewRounded fontSize="small" />
           </StyledExternalLink>
           <StyledExternalLink
-            href={FORUM_LINK}
+            href={FORUM_URL}
             rel="noreferrer noopener"
             target="_blank"
             variant="subtitle1"

--- a/apps/safe-claiming-app/src/widgets/SnapshotWidget.tsx
+++ b/apps/safe-claiming-app/src/widgets/SnapshotWidget.tsx
@@ -1,4 +1,3 @@
-import { useSafeAppsSDK } from "@gnosis.pm/safe-apps-react-sdk"
 import { OpenInNewRounded } from "@mui/icons-material"
 import {
   Box,
@@ -9,10 +8,11 @@ import {
   styled,
   Card,
 } from "@mui/material"
-import { CHAIN_CONSTANTS, FORUM_URL } from "src/config/constants"
+import { FORUM_URL } from "src/config/constants"
 import useSafeSnapshot, {
   type SnapshotProposal,
 } from "src/hooks/useSafeSnapshot"
+import { useSafeSnapshotSpace } from "src/hooks/useSnapshotSpace"
 import { SpaceContent } from "src/widgets/styles"
 import palette from "../config/colors"
 
@@ -128,8 +128,7 @@ const SnapshotProposals = ({
 )
 
 const SnapshotWidget = () => {
-  const { safe } = useSafeAppsSDK()
-  const snapshotSpace = CHAIN_CONSTANTS[safe.chainId]?.DELEGATE_ID
+  const snapshotSpace = useSafeSnapshotSpace()
 
   const SNAPSHOT_LINK = `https://snapshot.org/#/${snapshotSpace}`
   const PROPOSAL_AMOUNT = 3


### PR DESCRIPTION
## What it solves
Resolves #591 #590 https://github.com/safe-global/web-core/issues/1275

## How this PR fixes it
- removes buy-token-button
- rephrases text for no allocation
- fixes loading state to just a themed spinner
- goerli uses `tutis.eth` instead of `safe.eth`
- fixed size for voting power widget

## How to test it
- test governance widgets on goerli
  - use a safe without any tokens / allocation
  - use a safe which did not redeem all tokens yet
  - use a safe with token allocation
- when loading the app witness the spinner (only visible if network is slow)

## Screenshots
