### PR TITLE
chore: Bump `@gnosis.pm/safe-apps-provider` to v0.15.1

### DIFF
--- a/apps/drain-safe/package.json
+++ b/apps/drain-safe/package.json
@@ -3,7 +3,7 @@
   "version": "1.3.3",
   "private": true,
   "dependencies": {
-    "@gnosis.pm/safe-apps-provider": "^0.15.0",
+    "@gnosis.pm/safe-apps-provider": "^0.15.1",
     "@gnosis.pm/safe-react-components": "^1.2.0",
     "@material-ui/core": "^4.12.4",
     "@mui/x-data-grid": "4.0.2",

--- a/apps/drain-safe/package.json
+++ b/apps/drain-safe/package.json
@@ -3,7 +3,7 @@
   "version": "1.3.3",
   "private": true,
   "dependencies": {
-    "@gnosis.pm/safe-apps-provider": "^0.14.0",
+    "@gnosis.pm/safe-apps-provider": "^0.15.0",
     "@gnosis.pm/safe-react-components": "^1.2.0",
     "@material-ui/core": "^4.12.4",
     "@mui/x-data-grid": "4.0.2",

--- a/apps/safe-claiming-app/package.json
+++ b/apps/safe-claiming-app/package.json
@@ -7,7 +7,7 @@
     "@craco/craco": "^6.4.3",
     "@emotion/react": "^11.10.5",
     "@emotion/styled": "^11.10.5",
-    "@gnosis.pm/safe-apps-provider": "^0.15.0",
+    "@gnosis.pm/safe-apps-provider": "^0.15.1",
     "@mui/icons-material": "^5.10.9",
     "@mui/material": "^5.10.12",
     "bezier-easing": "^2.1.0",

--- a/apps/safe-claiming-app/package.json
+++ b/apps/safe-claiming-app/package.json
@@ -7,7 +7,7 @@
     "@craco/craco": "^6.4.3",
     "@emotion/react": "^11.10.5",
     "@emotion/styled": "^11.10.5",
-    "@gnosis.pm/safe-apps-provider": "^0.14.0",
+    "@gnosis.pm/safe-apps-provider": "^0.15.0",
     "@mui/icons-material": "^5.10.9",
     "@mui/material": "^5.10.12",
     "bezier-easing": "^2.1.0",

--- a/apps/tx-builder/package.json
+++ b/apps/tx-builder/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "homepage": "/tx-builder",
   "dependencies": {
-    "@gnosis.pm/safe-apps-provider": "^0.14.0",
+    "@gnosis.pm/safe-apps-provider": "^0.15.0",
     "@gnosis.pm/safe-deployments": "^1.16.0",
     "@gnosis.pm/safe-react-components": "1.1.5",
     "@material-ui/core": "^4.12.4",

--- a/apps/tx-builder/package.json
+++ b/apps/tx-builder/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "homepage": "/tx-builder",
   "dependencies": {
-    "@gnosis.pm/safe-apps-provider": "^0.15.0",
+    "@gnosis.pm/safe-apps-provider": "^0.15.1",
     "@gnosis.pm/safe-deployments": "^1.16.0",
     "@gnosis.pm/safe-react-components": "1.1.5",
     "@material-ui/core": "^4.12.4",

--- a/apps/wallet-connect/package.json
+++ b/apps/wallet-connect/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "homepage": "./",
   "dependencies": {
-    "@gnosis.pm/safe-apps-provider": "0.14.0",
+    "@gnosis.pm/safe-apps-provider": "0.15.0",
     "@gnosis.pm/safe-react-components": "^0.9.7",
     "@gnosis.pm/safe-react-gateway-sdk": "^2.10.1",
     "@walletconnect/client": "^1.8.0",

--- a/apps/wallet-connect/package.json
+++ b/apps/wallet-connect/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "homepage": "./",
   "dependencies": {
-    "@gnosis.pm/safe-apps-provider": "0.15.0",
+    "@gnosis.pm/safe-apps-provider": "0.15.1",
     "@gnosis.pm/safe-react-components": "^0.9.7",
     "@gnosis.pm/safe-react-gateway-sdk": "^2.10.1",
     "@walletconnect/client": "^1.8.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2178,10 +2178,10 @@
     "@ethersproject/properties" "^5.7.0"
     "@ethersproject/strings" "^5.7.0"
 
-"@gnosis.pm/safe-apps-provider@0.15.0", "@gnosis.pm/safe-apps-provider@^0.15.0":
-  version "0.15.0"
-  resolved "https://registry.yarnpkg.com/@gnosis.pm/safe-apps-provider/-/safe-apps-provider-0.15.0.tgz#8bc05bb1c23302ef58220e76fac68f7edee96aa2"
-  integrity sha512-TMZef4r8cYydpNIPGqozsOdATSJEMIMlJgR/j5IlwgcjCo811uyf9ie/UdzzViGV84N/12xDp20yiXLONReNXQ==
+"@gnosis.pm/safe-apps-provider@0.15.1", "@gnosis.pm/safe-apps-provider@^0.15.1":
+  version "0.15.1"
+  resolved "https://registry.yarnpkg.com/@gnosis.pm/safe-apps-provider/-/safe-apps-provider-0.15.1.tgz#1d070a7de87311190d09bb8e467137428c475d63"
+  integrity sha512-jVU0jpXf30HFdLHSHkmscIm04BYSwfoddjcHI4uPolP+u4F+tHRgfah1xo4XNRSCDqs4GTq38d7YAipGTj0CLA==
   dependencies:
     "@gnosis.pm/safe-apps-sdk" "7.8.0"
     events "^3.3.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2178,10 +2178,10 @@
     "@ethersproject/properties" "^5.7.0"
     "@ethersproject/strings" "^5.7.0"
 
-"@gnosis.pm/safe-apps-provider@0.14.0", "@gnosis.pm/safe-apps-provider@^0.14.0":
-  version "0.14.0"
-  resolved "https://registry.yarnpkg.com/@gnosis.pm/safe-apps-provider/-/safe-apps-provider-0.14.0.tgz#52783800f1da5f1b633a42dcf8c8797e7fe31d99"
-  integrity sha512-qOkPUfIu9dLoy4Muo40xzswqix7ZoJDmtEl35D+oYYa6JDw8cr4tVkPPjl6eDPNtMLiqGjs1POzHdZrfC8aHVw==
+"@gnosis.pm/safe-apps-provider@0.15.0", "@gnosis.pm/safe-apps-provider@^0.15.0":
+  version "0.15.0"
+  resolved "https://registry.yarnpkg.com/@gnosis.pm/safe-apps-provider/-/safe-apps-provider-0.15.0.tgz#8bc05bb1c23302ef58220e76fac68f7edee96aa2"
+  integrity sha512-TMZef4r8cYydpNIPGqozsOdATSJEMIMlJgR/j5IlwgcjCo811uyf9ie/UdzzViGV84N/12xDp20yiXLONReNXQ==
   dependencies:
     "@gnosis.pm/safe-apps-sdk" "7.8.0"
     events "^3.3.0"


### PR DESCRIPTION
## What it solves
Bumps `@gnosis.pm/safe-apps-provider` to v0.15.1, which adds support for custom a gas limit to be passed to transactions initiated through the safe app provider. For more information, see: https://github.com/safe-global/safe-apps-sdk/pull/398.