### PR TITLE
fix(safe-claiming-app): Snapshot widget state chip

### DIFF
--- a/apps/safe-claiming-app/src/hooks/useSafeSnapshot.ts
+++ b/apps/safe-claiming-app/src/hooks/useSafeSnapshot.ts
@@ -11,7 +11,7 @@ type ShapshotProposalVars = {
 export type SnapshotProposal = {
   id: string
   title: string
-  state: "active" | "closed"
+  state: "active" | "closed" | "pending"
   author: string
 }
 

--- a/apps/safe-claiming-app/src/widgets/SnapshotWidget.tsx
+++ b/apps/safe-claiming-app/src/widgets/SnapshotWidget.tsx
@@ -14,6 +14,12 @@ import useSafeSnapshot, {
 import { SpaceContent } from "src/widgets/styles"
 import palette from "../config/colors"
 
+const SNAPSHOT_STATE_COLORS: Record<SnapshotProposal["state"], string> = {
+  active: "success.main",
+  pending: "border.main",
+  closed: "#743EE4",
+}
+
 export const _getProposalNumber = (title: string): string => {
   // Find anything that matches "SEP #n"
   const SEP_REGEX = /SEP\s#\d+/g
@@ -42,7 +48,8 @@ const Proposal = styled("a")`
 
 const StyledChip = styled(Chip)`
   border-radius: 20px;
-  min-width: 68px;
+  min-width: 76px;
+  max-width: 76px;
   text-align: center;
   height: 23px;
   font-weight: bold;
@@ -113,8 +120,7 @@ const SnapshotProposals = ({
           sx={{
             gridArea: "status",
             color: palette.background.paper,
-            backgroundColor:
-              proposal.state === "active" ? "success.main" : "#743EE4",
+            backgroundColor: SNAPSHOT_STATE_COLORS[proposal.state],
           }}
         />
         <Box gridArea="link" display="flex" alignItems="center" ml="12px">


### PR DESCRIPTION
## What it solves
The state chip of the snapshot widget did not display the pending state correctly.

## How this PR fixes it
- Adds pending state to SnapshotProposal type
- Maps states to correct background colors

## How to test it
- Check the widget on goerli
- Observe pending proposal being displayed correctly

## Screenshots
![Screenshot 2022-12-02 at 08 35 17](https://user-images.githubusercontent.com/2670790/205239989-8bd96e25-27e5-4832-a18a-d9f72e0f8ff9.png)
