### PR TITLE
fix(tx-builder): Added clipboard permission to the `manifest.json` file

### DIFF
--- a/apps/tx-builder/public/manifest.json
+++ b/apps/tx-builder/public/manifest.json
@@ -8,5 +8,6 @@
       "sizes": "256x256",
       "type": "image/png"
     }
-  ]
+  ],
+  "safe_apps_permissions": ["clipboard-write"]
 }


### PR DESCRIPTION


## What it solves
Resolves #568 

## How this PR fixes it

Added `clipboard-write` permission in the `manifest.json` file

```
{
  "name": "Transaction Builder",
  "description": "A Safe app to compose custom transactions",
  "iconPath": "tx-builder.png",
  "icons": [
    {
      "src": "tx-builder.png",
      "sizes": "256x256",
      "type": "image/png"
    }
  ],
  "safe_apps_permissions": ["clipboard-write"]
}

```

## How to test it


Go to the current RC And check that you can copy the addresses into your clipboard

RC: https://release120--webcore.review-web-core.5afe.dev/


