### PR TITLE
chore: release with fix for loading state in safe-claiming-app

### DIFF
--- a/apps/safe-claiming-app/src/App.tsx
+++ b/apps/safe-claiming-app/src/App.tsx
@@ -98,11 +98,11 @@ const App = (): ReactElement => {
 
   const [safeTokenAllocation, allocationError, isVestingLoading] =
     useSafeTokenAllocation()
-  const { vestingData } = safeTokenAllocation
 
   const validVestingData = useMemo(
-    () => vestingData.filter((vesting) => !vesting.isExpired),
-    [vestingData]
+    () =>
+      safeTokenAllocation?.vestingData.filter((vesting) => !vesting.isExpired),
+    [safeTokenAllocation?.vestingData]
   )
 
   const [delegates, , delegatesFileError] = useDelegatesFile()
@@ -128,7 +128,7 @@ const App = (): ReactElement => {
   useEffect(() => {
     setAppState((prev) => ({
       ...prev,
-      vestingData: validVestingData,
+      vestingData: validVestingData ?? prev.vestingData,
       delegate: currentDelegate,
       isTokenPaused,
       delegateAddressFromContract,
@@ -152,10 +152,14 @@ const App = (): ReactElement => {
   }, [delegateAddressFromContract])
 
   useEffect(() => {
-    if (validVestingData.length === 0 && !isVestingLoading) {
+    if (
+      validVestingData &&
+      validVestingData.length === 0 &&
+      !isVestingLoading
+    ) {
       setActiveStep(NO_AIRDROP_STEP)
     }
-  }, [validVestingData.length, isVestingLoading])
+  }, [isVestingLoading, validVestingData])
 
   const handleBack = () => {
     if (activeStep === SUCCESS_STEP) {

--- a/apps/safe-claiming-app/src/widgets/ClaimingWidget.tsx
+++ b/apps/safe-claiming-app/src/widgets/ClaimingWidget.tsx
@@ -107,15 +107,15 @@ const ClaimingWidget = () => {
     }
   }, [delegateAddressFromContract, delegates])
 
-  const [safeTokenAllocation, loading] = useSafeTokenAllocation()
-  const { vestingData, votingPower } = safeTokenAllocation
+  const [safeTokenAllocation, , loading] = useSafeTokenAllocation()
+  const { vestingData, votingPower } = safeTokenAllocation ?? {}
 
-  const totalClaimed = vestingData.reduce(
+  const totalClaimed = vestingData?.reduce(
     (prev, current) => prev.add(current.amountClaimed),
     BigNumber.from(0)
   )
 
-  const unredeemedAllocations = vestingData.some(
+  const unredeemedAllocations = vestingData?.some(
     (vesting) => !vesting.isRedeemed
   )
 
@@ -149,11 +149,15 @@ const ClaimingWidget = () => {
         >
           <SafeIcon />
           <Typography variant="h5" color="text.primary">
-            {formatAmount(Number(ethers.utils.formatEther(votingPower)), 2)}{" "}
+            {votingPower ? (
+              formatAmount(Number(ethers.utils.formatEther(votingPower)), 2)
+            ) : (
+              <Skeleton />
+            )}{" "}
           </Typography>
         </Box>
       </div>
-      {totalClaimed.gt(0) ? (
+      {totalClaimed?.gt(0) ? (
         <>
           <Subtitle>
             You've already claimed{" "}
@@ -214,7 +218,7 @@ const ClaimingWidget = () => {
   return (
     <Card elevation={0} sx={{ minWidth: WIDGET_WIDTH, maxWidth: WIDGET_WIDTH }}>
       <SpaceContent sx={{ alignItems: "center" }}>
-        {votingPower.eq(0) ? ctaWidget : votingPowerWidget}
+        {votingPower && votingPower.eq(0) ? ctaWidget : votingPowerWidget}
       </SpaceContent>
     </Card>
   )


### PR DESCRIPTION
## What it solves
Fixes error in current main version where the app showed the "No Airdrop" screen for unredeemed allocations before the deadline was reached.

## How this PR fixes it
Fixes a bug in the loading state.

## How to test it
Use a Safe with unredeemed tokens on mainnet: It now correclty displays the claiming steps.
