### PR TITLE
style(safe-claiming-app): claiming app minor styles

### DIFF
--- a/apps/safe-claiming-app/src/components/steps/Claim/index.tsx
+++ b/apps/safe-claiming-app/src/components/steps/Claim/index.tsx
@@ -236,7 +236,7 @@ const Claim = ({ handleBack, state, handleUpdateState, handleNext }: Props) => {
                   variant="contained"
                   size="large"
                   disableElevation
-                  sx={{ width: 1, paddingX: 0 }}
+                  sx={{ width: 1, paddingX: 0, height: "47px" }}
                   disabled={buttonDisabled}
                   onClick={claimTokens}
                 >

--- a/apps/safe-claiming-app/src/widgets/ClaimingWidget.tsx
+++ b/apps/safe-claiming-app/src/widgets/ClaimingWidget.tsx
@@ -89,6 +89,14 @@ const StyledButton = (props: ButtonProps) => (
   </Button>
 )
 
+const StyledButtonLink = styled(Button)`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  margin-bottom: 8px;
+`
+
 const WIDGET_HEIGHT = 300
 
 const ClaimingWidget = () => {
@@ -140,29 +148,19 @@ const ClaimingWidget = () => {
     <>
       <div>
         <Title>Your voting power</Title>
-        <Link
+        <StyledButtonLink
           href={claimingSafeAppUrl}
-          rel="noopener noreferrer"
-          target="_blank"
-          underline="none"
+          sx={{ "&:hover": { backgroundColor: "secondary.light" } }}
         >
-          <Box
-            display="flex"
-            alignItems="center"
-            justifyContent="center"
-            gap={1}
-            mb={1}
-          >
-            <SafeIcon />
-            <Typography variant="h5" color="text.primary">
-              {votingPower ? (
-                formatAmount(Number(ethers.utils.formatEther(votingPower)), 2)
-              ) : (
-                <Skeleton />
-              )}{" "}
-            </Typography>
-          </Box>
-        </Link>
+          <SafeIcon />
+          <Typography variant="h5" color="text.primary">
+            {votingPower ? (
+              formatAmount(Number(ethers.utils.formatEther(votingPower)), 2)
+            ) : (
+              <Skeleton />
+            )}{" "}
+          </Typography>
+        </StyledButtonLink>
       </div>
       {totalClaimed?.gt(0) ? (
         <>
@@ -186,7 +184,10 @@ const ClaimingWidget = () => {
                 target="_blank"
                 underline="none"
               >
-                <SelectedDelegate delegate={currentDelegate} />
+                <SelectedDelegate
+                  delegate={currentDelegate}
+                  onClick={() => {}}
+                />
               </Link>
             </Box>
           )}

--- a/apps/safe-claiming-app/src/widgets/ClaimingWidget.tsx
+++ b/apps/safe-claiming-app/src/widgets/ClaimingWidget.tsx
@@ -150,7 +150,6 @@ const ClaimingWidget = () => {
         <Title>Your voting power</Title>
         <StyledButtonLink
           href={claimingSafeAppUrl}
-          rel="noopener noreferrer"
           target="_blank"
           sx={{ "&:hover": { backgroundColor: "secondary.light" } }}
         >

--- a/apps/safe-claiming-app/src/widgets/ClaimingWidget.tsx
+++ b/apps/safe-claiming-app/src/widgets/ClaimingWidget.tsx
@@ -89,14 +89,6 @@ const StyledButton = (props: ButtonProps) => (
   </Button>
 )
 
-const StyledButtonLink = styled(Button)`
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 8px;
-  margin-bottom: 8px;
-`
-
 const WIDGET_HEIGHT = 300
 
 const ClaimingWidget = () => {
@@ -148,10 +140,17 @@ const ClaimingWidget = () => {
     <>
       <div>
         <Title>Your voting power</Title>
-        <StyledButtonLink
+        <Button
           href={claimingSafeAppUrl}
           target="_blank"
-          sx={{ "&:hover": { backgroundColor: "secondary.light" } }}
+          sx={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            gap: "8px",
+            marginBottom: "8px",
+            "&:hover": { backgroundColor: "secondary.light" },
+          }}
         >
           <SafeIcon />
           <Typography variant="h5" color="text.primary">
@@ -161,7 +160,7 @@ const ClaimingWidget = () => {
               <Skeleton />
             )}{" "}
           </Typography>
-        </StyledButtonLink>
+        </Button>
       </div>
       {totalClaimed?.gt(0) ? (
         <>

--- a/apps/safe-claiming-app/src/widgets/ClaimingWidget.tsx
+++ b/apps/safe-claiming-app/src/widgets/ClaimingWidget.tsx
@@ -140,22 +140,29 @@ const ClaimingWidget = () => {
     <>
       <div>
         <Title>Your voting power</Title>
-        <Box
-          display="flex"
-          alignItems="center"
-          justifyContent="center"
-          gap={1}
-          mb={1}
+        <Link
+          href={claimingSafeAppUrl}
+          rel="noopener noreferrer"
+          target="_blank"
+          underline="none"
         >
-          <SafeIcon />
-          <Typography variant="h5" color="text.primary">
-            {votingPower ? (
-              formatAmount(Number(ethers.utils.formatEther(votingPower)), 2)
-            ) : (
-              <Skeleton />
-            )}{" "}
-          </Typography>
-        </Box>
+          <Box
+            display="flex"
+            alignItems="center"
+            justifyContent="center"
+            gap={1}
+            mb={1}
+          >
+            <SafeIcon />
+            <Typography variant="h5" color="text.primary">
+              {votingPower ? (
+                formatAmount(Number(ethers.utils.formatEther(votingPower)), 2)
+              ) : (
+                <Skeleton />
+              )}{" "}
+            </Typography>
+          </Box>
+        </Link>
       </div>
       {totalClaimed?.gt(0) ? (
         <>
@@ -173,7 +180,14 @@ const ClaimingWidget = () => {
               >
                 Delegated to
               </Typography>
-              <SelectedDelegate delegate={currentDelegate} />
+              <Link
+                href={claimingSafeAppUrl}
+                rel="noopener noreferrer"
+                target="_blank"
+                underline="none"
+              >
+                <SelectedDelegate delegate={currentDelegate} />
+              </Link>
             </Box>
           )}
         </>

--- a/apps/safe-claiming-app/src/widgets/ClaimingWidget.tsx
+++ b/apps/safe-claiming-app/src/widgets/ClaimingWidget.tsx
@@ -150,6 +150,8 @@ const ClaimingWidget = () => {
         <Title>Your voting power</Title>
         <StyledButtonLink
           href={claimingSafeAppUrl}
+          rel="noopener noreferrer"
+          target="_blank"
           sx={{ "&:hover": { backgroundColor: "secondary.light" } }}
         >
           <SafeIcon />


### PR DESCRIPTION
<!--
Remember to create a title following the Conventional Commits guidelines. Examples for valid PR titles are:

fix: Some thing found in the repo
feat: Add some feature
refactor!: Make some refactor
feat(wallet-connect): Add some feature

Note that since PR titles only have a single line, you have to use the ! syntax for breaking changes.

For more examples, take a look at:
- https://www.conventionalcommits.org/en/v1.0.0
-->

## What it solves
Resolves https://github.com/safe-global/safe-react-apps/issues/627

## How this PR fixes it
1. Gives the "Claim and delegate" button same height as the input field
2. Make "Voting Power" and "Delegate" parts of claiming widget clickable and navigate to the claiming app

## How to test it
1. Go to Claiming widget in Dashboard.
2. Click Safe icon or tokens value and you should navigate to the Claiming app
3. Click on the Delegate and you should navigate to the Claiming app

## Screenshots
<img width="581" alt="Screenshot 2023-01-04 at 10 35 52" src="https://user-images.githubusercontent.com/32431609/210536851-6e402c39-f802-463c-82c6-3127787d418d.png">
