### PR TITLE
fix(safe-claiming-app,mmi): fixes embedding of DM Sans font

### DIFF
--- a/apps/mmi/src/theme.ts
+++ b/apps/mmi/src/theme.ts
@@ -156,13 +156,13 @@ const theme = createTheme({
           font-family: 'DM Sans';
           font-display: swap;
           font-weight: 400;
-          src: url('/fonts/dm-sans-v11-latin-ext-regular.woff2') format('woff2');
+          src: url('/mmi/fonts/dm-sans-v11-latin-ext-regular.woff2') format('woff2');
         }
         @font-face {
           font-family: 'DM Sans';
           font-display: swap;
           font-weight: bold;
-          src: url('/fonts/dm-sans-v11-latin-ext-700.woff2') format('woff2');
+          src: url('/mmi/fonts/dm-sans-v11-latin-ext-700.woff2') format('woff2');
         }`,
     },
   },

--- a/apps/safe-claiming-app/src/components/AppSwitch.tsx
+++ b/apps/safe-claiming-app/src/components/AppSwitch.tsx
@@ -1,6 +1,11 @@
 import App from "src/App"
 import { useLightDarkTheme } from "src/hooks/useDarkMode"
-import { Box, CircularProgress, ThemeProvider } from "@mui/material"
+import {
+  Box,
+  CircularProgress,
+  CssBaseline,
+  ThemeProvider,
+} from "@mui/material"
 import Widget from "src/widgets/Widget"
 import SafeProvider from "@gnosis.pm/safe-apps-react-sdk"
 
@@ -10,6 +15,7 @@ export const AppSwitch = () => {
 
   return (
     <ThemeProvider theme={theme}>
+      <CssBaseline />
       <SafeProvider
         loader={
           <Box

--- a/apps/safe-claiming-app/src/index.tsx
+++ b/apps/safe-claiming-app/src/index.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { CssBaseline, GlobalStyles } from "@mui/material"
+import { GlobalStyles } from "@mui/material"
 
 import { render } from "react-dom"
 import { AppSwitch } from "./components/AppSwitch"
@@ -9,7 +9,6 @@ const container = document.getElementById("root") as HTMLDivElement
 render(
   <React.StrictMode>
     <GlobalStyles styles={{ body: { overflow: "hidden" } }} />
-    <CssBaseline />
     <AppSwitch />
   </React.StrictMode>,
   container


### PR DESCRIPTION
## What it solves
Both the claiming app  and MetaMask institutional were not loading the font correctly.

## How this PR fixes it
For the claiming app:
- `CSSBaseline` was not embedded inside the `ThemeProvider`

For MMI:
- The font had a wrong URL

## How to test it
Look at the font of both apps.
