### PR TITLE
feat(wallet-connect): EIP-1271 support

### DIFF
--- a/apps/drain-safe/package.json
+++ b/apps/drain-safe/package.json
@@ -6,7 +6,7 @@
     "@gnosis.pm/safe-react-components": "^1.2.0",
     "@material-ui/core": "^4.12.4",
     "@mui/x-data-grid": "4.0.2",
-    "@safe-global/safe-apps-provider": "^0.15.2",
+    "@safe-global/safe-apps-provider": "^0.16.0",
     "bignumber.js": "^9.1.0",
     "web3-eth-abi": "~1.8.1"
   },

--- a/apps/safe-claiming-app/package.json
+++ b/apps/safe-claiming-app/package.json
@@ -9,7 +9,7 @@
     "@emotion/styled": "^11.10.5",
     "@mui/icons-material": "^5.10.9",
     "@mui/material": "^5.10.12",
-    "@safe-global/safe-apps-provider": "^0.15.2",
+    "@safe-global/safe-apps-provider": "^0.16.0",
     "bezier-easing": "^2.1.0",
     "ethers": "^5.7.2",
     "react-twitter-embed": "^4.0.4"

--- a/apps/tx-builder/package.json
+++ b/apps/tx-builder/package.json
@@ -9,7 +9,7 @@
     "@material-ui/core": "^4.12.4",
     "@material-ui/icons": "^4.11.3",
     "@material-ui/lab": "^4.0.0-alpha.60",
-    "@safe-global/safe-apps-provider": "^0.15.2",
+    "@safe-global/safe-apps-provider": "^0.16.0",
     "axios": "^0.27.2",
     "evm-proxy-detection": "1.0.0",
     "localforage": "^1.10.0",

--- a/apps/wallet-connect/package.json
+++ b/apps/wallet-connect/package.json
@@ -5,7 +5,7 @@
   "homepage": "./",
   "dependencies": {
     "@gnosis.pm/safe-react-components": "^0.9.7",
-    "@safe-global/safe-apps-provider": "0.15.2",
+    "@safe-global/safe-apps-provider": "0.16.0",
     "@safe-global/safe-gateway-typescript-sdk": "^3.5.2",
     "@walletconnect/client": "^1.8.0",
     "@walletconnect/web3wallet": "^1.2.0",

--- a/apps/wallet-connect/src/hooks/useApps.ts
+++ b/apps/wallet-connect/src/hooks/useApps.ts
@@ -44,9 +44,13 @@ export function useApps(): UseAppsResponse {
 
   const findSafeApp = useCallback(
     (url: string): SafeAppData | undefined => {
-      let { hostname } = new URL(url)
+      try {
+        const { hostname } = new URL(url)
 
-      return safeAppsList.find(safeApp => safeApp.url.includes(hostname))
+        return safeAppsList.find(safeApp => safeApp.url.includes(hostname))
+      } catch (error) {
+        console.error('Unable to find Safe App:', error)
+      }
     },
     [safeAppsList],
   )

--- a/cypress/e2e/tx-builder/tx-builder.spec.cy.js
+++ b/cypress/e2e/tx-builder/tx-builder.spec.cy.js
@@ -44,7 +44,7 @@ describe('Testing Tx-builder safe app', { defaultCommandTimeout: 12000 }, () => 
     cy.findByRole('region').should('exist')
     cy.findByText('test Address Value').should('exist')
     cy.findByText('newValue(address):').should('exist')
-    cy.findAllByText('0x49d4...26A6').should('have.length', 2)
+    cy.findAllByText('0x49d4...26A6').should('have.length', 1)
   })
 
   it('should allow to create and send a complex batch', () => {
@@ -105,7 +105,7 @@ describe('Testing Tx-builder safe app', { defaultCommandTimeout: 12000 }, () => 
     cy.findByRole('region').should('exist')
     cy.findByText(/add owner with threshold/i).should('exist')
     cy.findByText('owner(address):').should('exist')
-    cy.findAllByText('0x49d4...26A6').should('have.length', 2)
+    cy.findAllByText('0x49d4...26A6').should('have.length', 1)
     cy.findByText('_threshold(uint256):').should('exist')
   })
 

--- a/package.json
+++ b/package.json
@@ -25,8 +25,8 @@
     "apps/*"
   ],
   "dependencies": {
-    "@safe-global/safe-apps-react-sdk": "^4.6.2",
-    "@safe-global/safe-apps-sdk": "^7.9.0",
+    "@safe-global/safe-apps-react-sdk": "^4.6.4",
+    "@safe-global/safe-apps-sdk": "^7.10.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-scripts": "5.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2755,25 +2755,25 @@
   resolved "https://registry.yarnpkg.com/@rushstack/eslint-patch/-/eslint-patch-1.1.1.tgz#782fa5da44c4f38ae9fd38e9184b54e451936118"
   integrity sha512-BUyKJGdDWqvWC5GEhyOiUrGNi9iJUr4CU0O2WxJL6QJhHeeA/NVBalH+FeK0r/x/W0rPymXt5s78TDS7d6lCwg==
 
-"@safe-global/safe-apps-provider@0.15.2", "@safe-global/safe-apps-provider@^0.15.2":
-  version "0.15.2"
-  resolved "https://registry.yarnpkg.com/@safe-global/safe-apps-provider/-/safe-apps-provider-0.15.2.tgz#fa5c30140134e72bb969da76b80a16c545323e3a"
-  integrity sha512-BaoGAuY7h6jLBL7P+M6b7hd+1QfTv8uMyNF3udhiNUwA0XwfzH2ePQB13IEV3Mn7wdcIMEEUDS5kHbtAsj60qQ==
+"@safe-global/safe-apps-provider@0.16.0", "@safe-global/safe-apps-provider@^0.16.0":
+  version "0.16.0"
+  resolved "https://registry.yarnpkg.com/@safe-global/safe-apps-provider/-/safe-apps-provider-0.16.0.tgz#55cb8ef168900fa13d4f4508a99ef00b565bf55d"
+  integrity sha512-oeRlvU+2hjFx/7EbskGq30kkwL2hyfdseZZZYf6na/xD85mZ59zKO81lBxZcWnvofJFqjqtScz84PAKth9Sq2g==
   dependencies:
-    "@safe-global/safe-apps-sdk" "7.9.0"
+    "@safe-global/safe-apps-sdk" "7.10.0"
     events "^3.3.0"
 
-"@safe-global/safe-apps-react-sdk@^4.6.2":
-  version "4.6.3"
-  resolved "https://registry.yarnpkg.com/@safe-global/safe-apps-react-sdk/-/safe-apps-react-sdk-4.6.3.tgz#e7627a60a4d45b7046c0aaf5f6cffb9caf86bb3b"
-  integrity sha512-mbTAICXyygHSmpxZYh7o3EJFewZ4rxgR6SPZ1/Ls2WwdV+viPrCpzUG66Iz9h0n0TtGKFlhzx800VkcAwBva7Q==
+"@safe-global/safe-apps-react-sdk@^4.6.4":
+  version "4.6.4"
+  resolved "https://registry.yarnpkg.com/@safe-global/safe-apps-react-sdk/-/safe-apps-react-sdk-4.6.4.tgz#7163cb10eb6af82489d199002cc94e0e58b41e97"
+  integrity sha512-QFrKZldFw0JY5jD/B6X2TzArgNuyWALpTjJair3ooYwRU5ZE6lWJ6W8FQg7XOogfRYoXbDhAtBXoGrX/BHbM4Q==
   dependencies:
-    "@safe-global/safe-apps-sdk" "7.9.0"
+    "@safe-global/safe-apps-sdk" "7.10.0"
 
-"@safe-global/safe-apps-sdk@7.9.0", "@safe-global/safe-apps-sdk@^7.9.0":
-  version "7.9.0"
-  resolved "https://registry.yarnpkg.com/@safe-global/safe-apps-sdk/-/safe-apps-sdk-7.9.0.tgz#0c79a7760470bfdaf4cce9aa5bceef56898c7037"
-  integrity sha512-S2EI+JL8ocSgE3uGNaDZCzKmwfhtxXZFDUP76vN0FeaY35itFMyi8F0Vhxu0XnZm3yLzJE3tp5px6GhuQFLU6w==
+"@safe-global/safe-apps-sdk@7.10.0", "@safe-global/safe-apps-sdk@^7.10.0":
+  version "7.10.0"
+  resolved "https://registry.yarnpkg.com/@safe-global/safe-apps-sdk/-/safe-apps-sdk-7.10.0.tgz#e75fc581126f27c52ec2601da51bca5eb99b61f4"
+  integrity sha512-is0QAHVoGkP06YfOPcp4X3/YUEA3wRdgFUyKZ4rT47uOEnzxA9Sm8BFJrIZqZOjjqC+aJXRMF0cE2qucS953rg==
   dependencies:
     "@safe-global/safe-gateway-typescript-sdk" "^3.5.3"
     ethers "^5.7.2"


### PR DESCRIPTION
## What it solves

Adds support for EIP-1271 in the WalletConnect app by updating the related dependencies.

## How this PR fixes it

The `safe-apps-provider`, `safe-apps-sdk` and `safe-apps-react-sdk` that support EIP-1271 have been updated.

## How to test it

Prerequisites:
- Open the https://github.com/safe-global/web-core/pull/1162 deployment.
- Run the [EIP-1271 test DApp](https://github.com/5afe/eip-1271-dapp) locally.
  - `main` branch can be used to test WC v1
  - `wallet-connect-v2` branch can be used to test WC v2 (with the env vars specified in `env.sample`).

Method:
1. Open the WC app in the aforementioned deployment.
2. Connect to the aforementioned test DApp
3. Toggle off-chain signing and attempt to sign a message.
4. Observe the off-chain signing modal.
5. Sign the message.
6. Observe the signed message in the "Signatures" tab of the transaction list.