### PR TITLE
fix(e2e): Change Safe Apps URL

### DIFF
--- a/cypress/e2e/drain-account/drain.spec.cy.js
+++ b/cypress/e2e/drain-account/drain.spec.cy.js
@@ -3,7 +3,7 @@ describe('Testing Drain Account safe app', { defaultCommandTimeout: 12000 }, () 
   const iframeSelector = `iframe[id="iframe-${appUrl}"]`
   const visitUrl = `/${Cypress.env('NETWORK_PREFIX')}:${Cypress.env(
     'TESTING_SAFE_ADDRESS',
-  )}/apps?appUrl=${encodeURIComponent(appUrl)}`
+  )}/apps/open?appUrl=${encodeURIComponent(appUrl)}`
 
   before(() => {
     cy.task('log', visitUrl)

--- a/cypress/e2e/safe-apps-check.spec.cy.js
+++ b/cypress/e2e/safe-apps-check.spec.cy.js
@@ -8,9 +8,9 @@ describe('Safe Apps List', () => {
   safeAppsList.forEach(safeApp => {
     it(safeApp.name, () => {
       cy.visitSafeApp(
-        `/${Cypress.env('NETWORK_PREFIX')}:${Cypress.env('TESTING_SAFE_ADDRESS')}/apps?appUrl=${
-          safeApp.url
-        }`,
+        `/${Cypress.env('NETWORK_PREFIX')}:${Cypress.env(
+          'TESTING_SAFE_ADDRESS',
+        )}/apps/open?appUrl=${safeApp.url}`,
         safeApp.url,
       )
       const iframeSelector = `iframe[id="iframe-${safeApp.url}"]`

--- a/cypress/e2e/tx-builder/tx-builder.spec.cy.js
+++ b/cypress/e2e/tx-builder/tx-builder.spec.cy.js
@@ -3,7 +3,7 @@ describe('Testing Tx-builder safe app', { defaultCommandTimeout: 12000 }, () => 
   const iframeSelector = `iframe[id="iframe-${appUrl}"]`
   const visitUrl = `/${Cypress.env('NETWORK_PREFIX')}:${Cypress.env(
     'TESTING_SAFE_ADDRESS',
-  )}/apps?appUrl=${encodeURIComponent(appUrl)}`
+  )}/apps/open?appUrl=${encodeURIComponent(appUrl)}`
 
   before(() => {
     cy.task('log', visitUrl)


### PR DESCRIPTION
## What it solves
Changed safe-apps URL in the web breaks cypress tests

## How this PR fixes it
By updating the URL

