### PR TITLE
fix(tx-builder,wallet-connect): update help centre link

### DIFF
--- a/apps/tx-builder/src/components/Header.tsx
+++ b/apps/tx-builder/src/components/Header.tsx
@@ -13,8 +13,7 @@ import { useTransactionLibrary } from '../store'
 import ChecksumWarning from './ChecksumWarning'
 import ErrorAlert from './ErrorAlert'
 
-const HELP_ARTICLE_LINK =
-  'https://help.gnosis-safe.io/en/articles/4680071-create-a-batched-transaction-with-the-transaction-builder-safe-app'
+const HELP_ARTICLE_LINK = 'https://help.safe.global/en/articles/40841-transaction-builder'
 
 const goBackLabel: Record<string, string> = {
   [CREATE_BATCH_PATH]: 'Back to Transaction Creation',

--- a/apps/wallet-connect/src/components/AppBar.tsx
+++ b/apps/wallet-connect/src/components/AppBar.tsx
@@ -2,7 +2,7 @@ import MuiAppBar from '@material-ui/core/AppBar'
 import styled from 'styled-components'
 import { Icon, Link, Text } from '@gnosis.pm/safe-react-components'
 
-const WALLET_CONNECT_HELP = 'https://help.gnosis-safe.io/en/articles/4356253-walletconnect-safe-app'
+const WALLET_CONNECT_HELP = 'https://help.safe.global/en/articles/40849-walletconnect-safe-app'
 
 const AppBar = () => {
   return (


### PR DESCRIPTION
Note: the links do not yet exist, but will [when the old Intercom is deactivated](https://5afe.slack.com/archives/C03BHKS5K6D/p1681831629917399?thread_ts=1681735283.046149&cid=C03BHKS5K6D). As such, releassing this needs to be aligned with a mobile release.

## What it solves
Resolves https://github.com/safe-global/web-core/issues/1875

## How this PR fixes it
All Help Center articles have been updated according to the [new links](https://docs.google.com/spreadsheets/d/1tZk_4EzXT3DOdqf3eGxkEcpO5R4W-22T2ncDbqeN4r4/edit#gid=0).

## How to test it
Observe the header links in the Transaction Builder/WalletConnect Safe Apps working.