### PR TITLE
fix(tx-builder): Open a window instead download batch for Safari and Firefox

### DIFF
--- a/apps/tx-builder/src/lib/storage.ts
+++ b/apps/tx-builder/src/lib/storage.ts
@@ -77,7 +77,7 @@ const downloadObjectAsJson = (batchFile: BatchFile) => {
   // https://bugzilla.mozilla.org/show_bug.cgi?id=1365502
   if (
     navigator.userAgent.includes('Firefox') ||
-    (navigator.userAgent.includes('Safari') && navigator.userAgent.includes('Chrome'))
+    (navigator.userAgent.includes('Safari') && !navigator.userAgent.includes('Chrome'))
   ) {
     return window.open(blobURL)
   }

--- a/apps/tx-builder/src/lib/storage.ts
+++ b/apps/tx-builder/src/lib/storage.ts
@@ -69,10 +69,12 @@ const getBatches = async () => {
 }
 
 const downloadObjectAsJson = (batchFile: BatchFile) => {
-  var blobURL = URL.createObjectURL(
+  const blobURL = URL.createObjectURL(
     new Blob([JSON.stringify(batchFile, stringifyReplacer)], { type: 'application/json' }),
   )
 
+  // If Firefox or Safari open a new window to download the file
+  // https://bugzilla.mozilla.org/show_bug.cgi?id=1365502
   if (
     navigator.userAgent.indexOf('Firefox') !== -1 ||
     (navigator.userAgent.indexOf('Safari') !== -1 && navigator.userAgent.indexOf('Chrome') === -1)

--- a/apps/tx-builder/src/lib/storage.ts
+++ b/apps/tx-builder/src/lib/storage.ts
@@ -69,14 +69,22 @@ const getBatches = async () => {
 }
 
 const downloadObjectAsJson = (batchFile: BatchFile) => {
-  const dataStr =
-    'data:text/json;charset=utf-8,' +
-    encodeURIComponent(JSON.stringify(batchFile, stringifyReplacer))
+  var blobURL = URL.createObjectURL(
+    new Blob([JSON.stringify(batchFile, stringifyReplacer)], { type: 'application/json' }),
+  )
+
+  if (
+    navigator.userAgent.indexOf('Firefox') !== -1 ||
+    (navigator.userAgent.indexOf('Safari') !== -1 && navigator.userAgent.indexOf('Chrome') === -1)
+  ) {
+    return window.open(blobURL)
+  }
+
   const downloadAnchorNode = document.createElement('a')
 
-  downloadAnchorNode.setAttribute('href', dataStr)
+  downloadAnchorNode.setAttribute('href', blobURL)
   downloadAnchorNode.setAttribute('download', batchFile.meta.name + '.json')
-  document.body.appendChild(downloadAnchorNode) // required for firefox
+  document.body.appendChild(downloadAnchorNode)
   downloadAnchorNode.click()
   downloadAnchorNode.remove()
 }

--- a/apps/tx-builder/src/lib/storage.ts
+++ b/apps/tx-builder/src/lib/storage.ts
@@ -76,8 +76,8 @@ const downloadObjectAsJson = (batchFile: BatchFile) => {
   // If Firefox or Safari open a new window to download the file
   // https://bugzilla.mozilla.org/show_bug.cgi?id=1365502
   if (
-    navigator.userAgent.indexOf('Firefox') !== -1 ||
-    (navigator.userAgent.indexOf('Safari') !== -1 && navigator.userAgent.indexOf('Chrome') === -1)
+    navigator.userAgent.includes('Firefox') ||
+    (navigator.userAgent.includes('Safari') && navigator.userAgent.includes('Chrome'))
   ) {
     return window.open(blobURL)
   }

--- a/apps/tx-builder/src/utils.ts
+++ b/apps/tx-builder/src/utils.ts
@@ -283,7 +283,7 @@ export const evalTemplate = (templateUri: string, data: Record<string, string>):
   return templateUri.replace(TEMPLATE_REGEX, (_: string, key: string) => data[key])
 }
 
-const OLD_BASE_URL = 'https://gnosis-safe.io'
+const OLD_BASE_URL = 'https://apps.gnosis-safe.io'
 export const OLD_TX_BUILDER_URL = `${OLD_BASE_URL}/tx-builder/`
 
 const NEW_BASE_URL = 'https://apps-portal.safe.global'


### PR DESCRIPTION
## What it solves
Resolves https://github.com/safe-global/safe-react-apps/issues/660

## How this PR fixes it
By using a blob and opening it in a new window (Firefox and Safari) or directly downloading (Chrome).
It is not the perfect solution but CSP policy is not allowing the download from the iframe. This is a [know bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1365502)

## How to test it
1) Test that the generated file is exactly the same and that can be exported/imported
2) Chrome should behave the same downloading the file
3) Firefox and Safari should open a new window showing the file and should allow to download it from there
