### PR TITLE
fix(tx-builder): Open required app in new window

### DIFF
--- a/apps/tx-builder/src/components/Banner/index.tsx
+++ b/apps/tx-builder/src/components/Banner/index.tsx
@@ -7,14 +7,19 @@ import { OLD_TX_BUILDER_URL, NEW_TX_BUILDER_URL, isOldDomain } from '../../utils
 import { localItem } from '../../lib/local-storage/local'
 import { useState } from 'react'
 import css from './styles.module.css'
+import { useSafeAppsSDK } from '@safe-global/safe-apps-react-sdk'
 
 const LS_KEY = 'rememberExportedBatches'
 
-const NewDomainBody = ({ onClose }: { onClose: () => void }) => (
+const openSafeApp = (safe: string, safeAppUrl: string) => {
+  window.open(`https://app.safe.global/apps/open?safe=${safe}&appUrl=${safeAppUrl}`, '_blank')
+}
+
+const NewDomainBody = ({ safe, onClose }: { safe: string; onClose: () => void }) => (
   <>
     <Text size="xl" className={css.description}>
       Please make sure to migrate all transaction batches from the{' '}
-      <Link href={OLD_TX_BUILDER_URL} size="xl">
+      <Link onClick={() => openSafeApp(safe, OLD_TX_BUILDER_URL)} size="xl">
         old Transaction Builder
       </Link>{' '}
       before <b>1st September</b>.
@@ -25,12 +30,12 @@ const NewDomainBody = ({ onClose }: { onClose: () => void }) => (
   </>
 )
 
-const OldDomainBody = () => (
+const OldDomainBody = ({ safe }: { safe: string }) => (
   <>
     <Text size="xl" className={css.description}>
       Please make sure to export all transaction batches before 1st September in order to import
       them in the{' '}
-      <Link href={NEW_TX_BUILDER_URL} size="xl">
+      <Link onClick={() => openSafeApp(safe, NEW_TX_BUILDER_URL)} size="xl">
         new Transaction Builder
       </Link>
       .
@@ -42,6 +47,7 @@ const OldDomainBody = () => (
 )
 
 const Banner = () => {
+  const { safe } = useSafeAppsSDK()
   const storedValue = localItem<boolean>(LS_KEY).get()
   const [showBanner, setShowBanner] = useState<boolean>(storedValue ?? true)
 
@@ -61,7 +67,11 @@ const Banner = () => {
       <StyledTitle size="xs" strong withoutMargin>
         New Transaction Builder domain
       </StyledTitle>
-      {isOldDomain ? <OldDomainBody /> : <NewDomainBody onClose={handleClose} />}
+      {isOldDomain ? (
+        <OldDomainBody safe={safe.safeAddress} />
+      ) : (
+        <NewDomainBody safe={safe.safeAddress} onClose={handleClose} />
+      )}
     </Paper>
   ) : null
 }

--- a/apps/tx-builder/src/utils.ts
+++ b/apps/tx-builder/src/utils.ts
@@ -284,9 +284,9 @@ export const evalTemplate = (templateUri: string, data: Record<string, string>):
 }
 
 const OLD_BASE_URL = 'https://apps.gnosis-safe.io'
-export const OLD_TX_BUILDER_URL = `${OLD_BASE_URL}/tx-builder/`
+export const OLD_TX_BUILDER_URL = `${OLD_BASE_URL}/tx-builder`
 
 const NEW_BASE_URL = 'https://apps-portal.safe.global'
-export const NEW_TX_BUILDER_URL = `${NEW_BASE_URL}/tx-builder/`
+export const NEW_TX_BUILDER_URL = `${NEW_BASE_URL}/tx-builder`
 
-export const isOldDomain = window.location.href === OLD_TX_BUILDER_URL
+export const isOldDomain = decodeURIComponent(window.location.href).includes(OLD_TX_BUILDER_URL)


### PR DESCRIPTION
## What it solves
Currently the banner to migrate the transaction batches is redirecting internally to the new application. The user can't notice any change in the UI as the URL for the parent is not changing

In this PR we are opening the required app (old or new) in a new window tab
