### PR TITLE
fix(wallet-connect): only support required session methods

### DIFF
--- a/apps/wallet-connect/src/hooks/useWalletConnectV2.tsx
+++ b/apps/wallet-connect/src/hooks/useWalletConnectV2.tsx
@@ -168,9 +168,8 @@ const useWalletConnectV2 = (
       // events
       web3wallet.on('session_proposal', async proposal => {
         const { id, params } = proposal
-        const { requiredNamespaces, optionalNamespaces } = params
+        const { requiredNamespaces } = params
         const EIP155Namespace = requiredNamespaces[EVMBasedNamespaces]
-        const optionalEIP155Namespace = optionalNamespaces[EVMBasedNamespaces]
 
         // at least a EVM-based (eip155) namespace should be present
         const isEIP155NamespacePresent = !!EIP155Namespace
@@ -218,7 +217,7 @@ const useWalletConnectV2 = (
                 accounts: safeAccount || [
                   `${EVMBasedNamespaces}:${safe.chainId}:${safe.safeAddress}`,
                 ],
-                methods: [...EIP155Namespace.methods, ...(optionalEIP155Namespace?.methods || [])],
+                methods: EIP155Namespace.methods,
                 events: EIP155Namespace.events,
               },
             },


### PR DESCRIPTION
Fixes https://github.com/safe-global/safe-react-apps/issues/709.

When a dapp wants to connect to a wallet using WalletConnect V2, it needs to propose a session. In the proposed session, the dapp declares which RPC methods are required for it to work properly. It can also declare additional optional methods.

If the wallet application supports the required methods, but only a subset of the optional methods, it should approve the session with only the method/namespace it supports.

In the WalletConnect Safe App, we're approving ALL the methods requested (required + optional) even when the Wallet Connect Safe App doesn't support them. This is happening here: https://github.com/safe-global/safe-react-apps/blob/development/apps/wallet-connect/src/hooks/useWalletConnectV2.tsx#L221

Instead of approving the session with all the requested methods, only supported methods should be approved.

As an immediate solution, we're dropping the blind support of optional methods and only declaring support for required methods.

Further work should be done to only support the methods actually supported. The list of currently supported methods can be found in the [safe-apps-provider](https://github.com/safe-global/safe-apps-sdk/blob/main/packages/safe-apps-provider/src/provider.ts#L32).