### PR TITLE
fix(wallet-connect): Improved Walletconnect rejection messages to dApps

### DIFF
--- a/apps/wallet-connect/package.json
+++ b/apps/wallet-connect/package.json
@@ -8,7 +8,6 @@
     "@safe-global/safe-apps-provider": "0.17.0",
     "@safe-global/safe-gateway-typescript-sdk": "^3.7.3",
     "@walletconnect/client": "^1.8.0",
-    "@walletconnect/utils": "^2.9.0",
     "@walletconnect/web3wallet": "^1.8.6",
     "date-fns": "^2.30.0",
     "ethers": "^5.7.2",

--- a/apps/wallet-connect/src/App.test.tsx
+++ b/apps/wallet-connect/src/App.test.tsx
@@ -37,7 +37,7 @@ const version2URI =
   'wc:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx@2?relay-protocol=irn&symKey=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'
 
 const invalidConnectionErrorLabel =
-  'Connection refused: the dApp you are using is sending an incompatible connection proposal with your Safe Account'
+  'Connection refused: the dApp you are using is sending a connection proposal that is incompatible with your Safe Account'
 
 jest.mock('@safe-global/safe-gateway-typescript-sdk', () => {
   return {

--- a/apps/wallet-connect/src/hooks/useWalletConnectV2.tsx
+++ b/apps/wallet-connect/src/hooks/useWalletConnectV2.tsx
@@ -14,7 +14,6 @@ import {
   WALLET_CONNECT_VERSION_2,
 } from '../utils/analytics'
 import { isProduction, SAFE_WALLET_METADATA, WALLETCONNECT_V2_PROJECT_ID } from '../constants'
-import { buildApprovedNamespaces } from '@walletconnect/utils'
 
 const EVMBasedNamespaces: string = 'eip155'
 
@@ -53,6 +52,9 @@ const USER_REJECTED_REQUEST_CODE = 4001
 const USER_DISCONNECTED_CODE = 6000
 
 const logger = isProduction ? undefined : 'debug'
+
+export const errorLabel =
+  'Connection refused: the dApp you are using is sending an incompatible connection proposal with your Safe Account'
 
 export type wcConnectType = (uri: string) => Promise<void>
 export type wcDisconnectType = () => Promise<void>
@@ -197,69 +199,25 @@ const useWalletConnectV2 = (
       // events
       web3wallet.on('session_proposal', async proposal => {
         const { id, params } = proposal
-        const { requiredNamespaces, optionalNamespaces } = params
-
-        const requiredEIP155Namespace =
-          requiredNamespaces[EVMBasedNamespaces] || optionalNamespaces[EVMBasedNamespaces]
+        const { requiredNamespaces } = params
 
         console.log('Session proposal: ', proposal)
 
-        // EVM-based (eip155) namespace should be present
-        const isEIP155NamespacePresent = !!requiredEIP155Namespace
-
-        if (!isEIP155NamespacePresent) {
-          const errorMessage = getConnectionErrorMessage('chains error', chainInfo?.chainName)
-          setError(errorMessage)
-
-          await web3wallet.rejectSession({
-            id: proposal.id,
-            reason: {
-              code: UNSUPPORTED_CHAIN_ERROR_CODE,
-              message: `Unsupported chains. No EVM-based (${EVMBasedNamespaces}) namespace present in the session proposal`,
-            },
-          })
-          return
-        }
-
-        const safeChain = `${EVMBasedNamespaces}:${safe.chainId}`
         const safeAccount = `${EVMBasedNamespaces}:${safe.chainId}:${safe.safeAddress}`
-        const safeEvents = requiredEIP155Namespace.events // we accept all events like chainChanged & accountsChanged (even if they are not compatible with the Safe)
-
-        // The Safe chain should be present
-        const isSafeChainPresent = requiredEIP155Namespace?.chains?.some(
-          namespace => namespace === safeChain,
-        )
-
-        if (!isSafeChainPresent) {
-          const errorMessage = getConnectionErrorMessage('chains error', chainInfo?.chainName)
-          setError(errorMessage)
-
-          await web3wallet.rejectSession({
-            id: proposal.id,
-            reason: {
-              code: UNSUPPORTED_CHAIN_ERROR_CODE,
-              message: `Wrong chains in proposal. The current Safe chain (${safeChain}) is not present in the session proposal`,
-            },
-          })
-          return
-        }
+        const safeChain = `${EVMBasedNamespaces}:${safe.chainId}`
+        const safeEvents = requiredNamespaces[EVMBasedNamespaces]?.events || [] // we accept all events like chainChanged & accountsChanged (even if they are not compatible with the Safe)
 
         try {
-          const approvedSafeNamespaces = buildApprovedNamespaces({
-            proposal: params,
-            supportedNamespaces: {
+          const wcSession = await web3wallet.approveSession({
+            id,
+            namespaces: {
               eip155: {
+                accounts: [safeAccount], // only the Safe account
                 chains: [safeChain], // only the Safe chain
                 methods: compatibleSafeMethods, // only the Safe methods
                 events: safeEvents,
-                accounts: [safeAccount], // only the Safe account
               },
             },
-          })
-
-          const wcSession = await web3wallet.approveSession({
-            id,
-            namespaces: approvedSafeNamespaces,
           })
 
           trackEvent(NEW_SESSION_ACTION, WALLET_CONNECT_VERSION_2, wcSession.peer.metadata)
@@ -268,9 +226,19 @@ const useWalletConnectV2 = (
           setError(undefined)
         } catch (error: any) {
           console.log('error: ', error)
-          console.log('error: ', error.message)
-          const errorMessage = getConnectionErrorMessage(error.message, chainInfo?.chainName)
-          setError(errorMessage)
+
+          // human readeable error
+          setError(errorLabel)
+
+          const errorMessage = `Connection refused: This Safe Account is in ${chainInfo?.chainName} but the Wallet Connect session proposal is not valid because it contains: 1) A required chain different than ${chainInfo?.chainName} 2) Does not include ${chainInfo?.chainName} between the optional chains 3) No EVM compatible chain is included`
+          console.log(errorMessage)
+          await web3wallet.rejectSession({
+            id: proposal.id,
+            reason: {
+              code: UNSUPPORTED_CHAIN_ERROR_CODE,
+              message: errorMessage,
+            },
+          })
         }
       })
 
@@ -324,20 +292,4 @@ const rejectResponse = (id: number, code: number, message: string) => {
       message,
     },
   }
-}
-
-const getConnectionErrorMessage = (errorMessage = '', chainName = ''): string => {
-  const isChainError = errorMessage.includes('chains')
-
-  if (isChainError) {
-    return `Connection refused: This Safe Account is in ${chainName} but the Wallet Connect session proposal is not valid because it contains: 1) A required chain different than ${chainName} 2) Does not include ${chainName} between the optional chains 3) No EVM compatible chain is included`
-  }
-
-  const isMethodError = errorMessage.includes('methods')
-
-  if (isMethodError) {
-    return 'Connection refused: Incompatible methods between the Dapp and the Safe Account detected.'
-  }
-
-  return errorMessage
 }

--- a/apps/wallet-connect/src/hooks/useWalletConnectV2.tsx
+++ b/apps/wallet-connect/src/hooks/useWalletConnectV2.tsx
@@ -54,7 +54,7 @@ const USER_DISCONNECTED_CODE = 6000
 const logger = isProduction ? undefined : 'debug'
 
 export const errorLabel =
-  'Connection refused: the dApp you are using is sending an incompatible connection proposal with your Safe Account'
+  'Connection refused: the dApp you are using is sending a connection proposal that is incompatible with your Safe Account'
 
 export type wcConnectType = (uri: string) => Promise<void>
 export type wcDisconnectType = () => Promise<void>

--- a/yarn.lock
+++ b/yarn.lock
@@ -4219,7 +4219,7 @@
     query-string "7.1.3"
     uint8arrays "^3.1.0"
 
-"@walletconnect/utils@2.9.0", "@walletconnect/utils@^2.9.0":
+"@walletconnect/utils@2.9.0":
   version "2.9.0"
   resolved "https://registry.yarnpkg.com/@walletconnect/utils/-/utils-2.9.0.tgz#c73925edb9fefe79021bcf028e957028f986b728"
   integrity sha512-7Tu3m6dZL84KofrNBcblsgpSqU2vdo9ImLD7zWimLXERVGNQ8smXG+gmhQYblebIBhsPzjy9N38YMC3nPlfQNw==


### PR DESCRIPTION
## What it solves

Added new Walletconnect rejection messages

```
Connection refused: the dApp you are using is sending a connection proposal that is incompatible with your Safe Account
```

## How this PR fixes it

## How to test it

## Screenshots

![Captura de pantalla 2023-07-10 a las 11 41 42](https://github.com/safe-global/safe-react-apps/assets/26763673/f6dccfa7-0a32-48f2-a0f8-a9fba1cdbcb9)



