### PR TITLE
fix(ramp-network): add input to release action

### DIFF
--- a/.github/actions/release/action.yml
+++ b/.github/actions/release/action.yml
@@ -36,6 +36,9 @@ inputs:
   react-app-walletconnect-project-id:
     description: WalletConnect Project ID
     required: true
+  react-app-ramp-api:
+    description: Ramp network API Key
+    required: true
 
 runs:
   using: composite


### PR DESCRIPTION

## What it solves
The release action.yml was missing the input for the ramp network API key.

## How this PR fixes it
Adds it to the action.yml

