### PR TITLE
fix(ramp-network): upgrade ramp SDK to 4.0.4

### DIFF
--- a/apps/ramp-network/package.json
+++ b/apps/ramp-network/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@gnosis.pm/safe-react-components": "^0.9.7",
     "@material-ui/core": "^4.12.4",
-    "@ramp-network/ramp-instant-sdk": "^3.0.0"
+    "@ramp-network/ramp-instant-sdk": "^4.0.4"
   },
   "scripts": {
     "start": "react-app-rewired start",

--- a/apps/ramp-network/src/App.tsx
+++ b/apps/ramp-network/src/App.tsx
@@ -3,7 +3,7 @@ import { useSafeAppsSDK } from '@safe-global/safe-apps-react-sdk'
 import { Title, Loader, Text } from '@gnosis.pm/safe-react-components'
 import { ChainInfo } from '@safe-global/safe-apps-sdk'
 import { goBack } from './utils'
-import { ASSETS_BY_CHAIN, getRampWidgetUrl, initializeRampWidget } from './ramp'
+import { ASSETS_BY_CHAIN, initializeRampWidget } from './ramp'
 import styled from 'styled-components'
 
 const Container = styled.div`
@@ -45,7 +45,6 @@ const SafeApp = (): React.ReactElement | null => {
   useEffect(() => {
     if (chainInfo && safe && isChainSupported) {
       initializeRampWidget({
-        url: getRampWidgetUrl(chainInfo),
         address: safe.safeAddress,
         assets: ASSETS_BY_CHAIN[chainInfo.chainId],
         onClose: goBack,

--- a/apps/ramp-network/src/ramp.ts
+++ b/apps/ramp-network/src/ramp.ts
@@ -20,15 +20,13 @@ export const getRampWidgetUrl = (chainInfo: ChainInfo) => {
 }
 
 type RampWidgetInitializer = {
-  url?: string
   assets: string
   address: string
   onClose?: () => void
 }
 
-export const initializeRampWidget = ({ url, assets, address, onClose }: RampWidgetInitializer) => {
+export const initializeRampWidget = ({ assets, address, onClose }: RampWidgetInitializer) => {
   return new RampInstantSDK({
-    url,
     hostAppName: 'Ramp Network Safe App',
     hostLogoUrl: 'https://docs.ramp.network/img/logo-1.svg',
     swapAsset: assets,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2845,12 +2845,12 @@
   resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.11.6.tgz#cee20bd55e68a1720bdab363ecf0c821ded4cd45"
   integrity sha512-50/17A98tWUfQ176raKiOGXuYpLyyVMkxxG6oylzL3BPOlA6ADGdK7EYunSa4I064xerltq9TGXs8HmOk5E+vw==
 
-"@ramp-network/ramp-instant-sdk@^3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@ramp-network/ramp-instant-sdk/-/ramp-instant-sdk-3.0.0.tgz#b4553d80563f98952ef28df42d266ca2d3fe53a9"
-  integrity sha512-wkP87bkTabPs6VPeuRe4tVB1M4NF5NdhgkglExC38LYZXOmyfw0UF5MVpLiIAezUDiDqOhzgBnJxX3QvbeS2kA==
+"@ramp-network/ramp-instant-sdk@^4.0.4":
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/@ramp-network/ramp-instant-sdk/-/ramp-instant-sdk-4.0.4.tgz#25e1327ff2aead8bbab3c1cb5257da9041867442"
+  integrity sha512-Kkn+xwc4EbD2YqXOOQChZCqRT8/DM8sh9Qnz1nI2+/ACdo3INc42FMubgw5aZlyBzuF32XL/xdZyWBGPF4vECg==
   dependencies:
-    body-scroll-lock "^2.6.4"
+    body-scroll-lock "^3.1.5"
 
 "@remix-run/router@1.0.3":
   version "1.0.3"
@@ -5299,10 +5299,10 @@ body-parser@1.19.2, body-parser@^1.16.0:
     raw-body "2.4.3"
     type-is "~1.6.18"
 
-body-scroll-lock@^2.6.4:
-  version "2.7.1"
-  resolved "https://registry.yarnpkg.com/body-scroll-lock/-/body-scroll-lock-2.7.1.tgz#caf3f9c91773af1ffb684cd66ed9137b5b737014"
-  integrity sha512-hS53SQ8RhM0e4DsQ3PKz6Gr2O7Kpdh59TWU98GHjaQznL7y4dFycEPk7pFQAikqBaUSCArkc5E3pe7CWIt2fZA==
+body-scroll-lock@^3.1.5:
+  version "3.1.5"
+  resolved "https://registry.yarnpkg.com/body-scroll-lock/-/body-scroll-lock-3.1.5.tgz#c1392d9217ed2c3e237fee1e910f6cdd80b7aaec"
+  integrity sha512-Yi1Xaml0EvNA0OYWxXiYNqY24AfWkbA6w5vxE7GWxtKfzIbZM+Qw+aSmkgsbWzbHiy/RCSkUZBplVxTA+E4jJg==
 
 bonjour@^3.5.0:
   version "3.5.0"


### PR DESCRIPTION
The old sdk was using a deprecated ramp URL. The new SDK fixes this.

## What it solves
The ramp app does not load anymore.

## How this PR fixes it
Upgrades ramp sdk to 4.0.4

## How to test it
- Load the Ramp App
- Witness the widget loading now
