### PR TITLE
feat: add support for additional chains on ramp

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -23,7 +23,7 @@ jobs:
           # branch should not be protected
           branch: 'main'
           # user names of users allowed to contribute without CLA
-          allowlist: rmeissner,germartinez,Uxio0,dasanra,francovenica,luarx,DaniSomoza,yagopv,JagoFigueroa,bot*
+          allowlist: rmeissner,germartinez,Uxio0,dasanra,francovenica,luarx,DaniSomoza,yagopv,JagoFigueroa,jmealy,bot*
 
           # the followings are the optional inputs - If the optional inputs are not given, then default values will be taken
           # enter the remote organization name where the signatures should be stored (Default is storing the signatures in the same repository)

--- a/apps/ramp-network/src/ramp.ts
+++ b/apps/ramp-network/src/ramp.ts
@@ -14,9 +14,9 @@ export const ASSETS_BY_CHAIN: { [key: string]: string } = {
   '100': 'XDAI_*',
   '43114': 'AVAX_*',
   '8453': 'ETH_*,ERC20_*', // Base
-  '42161': 'ETH_*,ERC20_*', //Arbitrum
   '324': 'ETH_*,ERC20_*', // zkSync
   '1101': 'ETH_*,ERC20_*', // Polygon zkEvm
+  '42161': 'ARBITRUM_*,ETH_*,ERC20_*', //Arbitrum
   '42220': 'CELO_*',
 }
 

--- a/apps/ramp-network/src/ramp.ts
+++ b/apps/ramp-network/src/ramp.ts
@@ -13,6 +13,11 @@ export const ASSETS_BY_CHAIN: { [key: string]: string } = {
   '137': 'MATIC_*',
   '100': 'XDAI_*',
   '43114': 'AVAX_*',
+  '8453': 'ETH_*,ERC20_*', // Base
+  '42161': 'ETH_*,ERC20_*', //Arbitrum
+  '324': 'ETH_*,ERC20_*', // zkSync
+  '1101': 'ETH_*,ERC20_*', // Polygon zkEvm
+  '42220': 'CELO_*',
 }
 
 export const getRampWidgetUrl = (chainInfo: ChainInfo) => {

--- a/apps/ramp-network/src/ramp.ts
+++ b/apps/ramp-network/src/ramp.ts
@@ -13,9 +13,9 @@ export const ASSETS_BY_CHAIN: { [key: string]: string } = {
   '137': 'MATIC_*',
   '100': 'XDAI_*',
   '43114': 'AVAX_*',
-  '8453': 'ETH_*,ERC20_*', // Base
-  '324': 'ETH_*,ERC20_*', // zkSync
-  '1101': 'ETH_*,ERC20_*', // Polygon zkEvm
+  '8453': 'BASE_*',
+  '324': 'ZKSYNCERA_*',
+  '1101': 'POLYGONZKEVM_*',
   '42161': 'ARBITRUM_*',
   '42220': 'CELO_*',
 }

--- a/apps/ramp-network/src/ramp.ts
+++ b/apps/ramp-network/src/ramp.ts
@@ -16,7 +16,7 @@ export const ASSETS_BY_CHAIN: { [key: string]: string } = {
   '8453': 'ETH_*,ERC20_*', // Base
   '324': 'ETH_*,ERC20_*', // zkSync
   '1101': 'ETH_*,ERC20_*', // Polygon zkEvm
-  '42161': 'ARBITRUM_*,ETH_*,ERC20_*', //Arbitrum
+  '42161': 'ARBITRUM_*',
   '42220': 'CELO_*',
 }
 


### PR DESCRIPTION
## What it solves
Resolves #784

## How this PR fixes it
- Add the following chains to the allowed list:
    - Arbitrum
    - Base
    - Celo
    - zkSync Era
    - zkEVM

## How to test it
- Try to use the Ramp safe app while in a wallet using each of the chains above.
- The app will load without any errors.

Docs: https://docs.ramp.network/assets

## Screenshots
![Screenshot 2024-01-19 at 14 14 26](https://github.com/safe-global/safe-react-apps/assets/381895/fb00f2c7-340e-4afa-a098-dd5c94a3ba47)
