### PR TITLE
chore(tx-builder): bump safe-deployments to version 1.37.30

### DIFF
--- a/apps/tx-builder/package.json
+++ b/apps/tx-builder/package.json
@@ -9,7 +9,7 @@
     "@material-ui/icons": "^4.11.3",
     "@material-ui/lab": "^4.0.0-alpha.60",
     "@safe-global/safe-apps-provider": "^0.18.0",
-    "@safe-global/safe-deployments": "^1",
+    "@safe-global/safe-deployments": "^1.37.30",
     "@safe-global/safe-gateway-typescript-sdk": "^3.19.0",
     "axios": "^1.6.0",
     "evm-proxy-detection": "1.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2922,10 +2922,10 @@
     "@safe-global/safe-gateway-typescript-sdk" "^3.5.3"
     viem "^1.0.0"
 
-"@safe-global/safe-deployments@^1":
-  version "1.37.24"
-  resolved "https://registry.yarnpkg.com/@safe-global/safe-deployments/-/safe-deployments-1.37.24.tgz#e76634669d2ec3dd254850e055d18496246556c6"
-  integrity sha512-jBbPRi/qimF70Zi9Ri49aEOMEO+J8KNvohzs4gs90YF9LH6GraylVDMrqi5i3gQIyyICkQbjYYsS/Ax+Po7sDw==
+"@safe-global/safe-deployments@^1.37.30":
+  version "1.37.30"
+  resolved "https://registry.yarnpkg.com/@safe-global/safe-deployments/-/safe-deployments-1.37.30.tgz#6b9654b429424a3081ec99e34753fe933bf59746"
+  integrity sha512-fARm/2VkT4Om/EoaVG4G/TvxaXnVfJZQrsXi/3eDcIB0NwkjgTHoku7FfdY4Gl3EINCaUHnWT9t7CNMPJu/I5w==
   dependencies:
     semver "^7.6.2"
 


### PR DESCRIPTION
fix: Transaction Builder needs the latest version of safe-deployments for simulation on the latest chains.

