### PR TITLE
fix: error: Can't resolve 'process/browser' in axios

### DIFF
--- a/apps/tx-builder/config-overrides.js
+++ b/apps/tx-builder/config-overrides.js
@@ -26,6 +26,8 @@ module.exports = {
       }),
     ])
 
+    config.module.rules.push({ test: /\.m?js/, resolve: { fullySpecified: false } })
+
     // https://github.com/facebook/create-react-app/issues/11924
     config.ignoreWarnings = [/to parse source map/i]
 


### PR DESCRIPTION


## What it solves
After merging some of the dependabot PRs it turned out that the build for tx-builder was not succeeding and was failng with 

> Compiled with problems:X
> 
> ERROR in ../../node_modules/axios/lib/utils.js 714:91-98
> 
> Module not found: Error: Can't resolve 'process/browser' in '.../safe-react-apps/node_modules/axios/lib'
> Did you mean 'browser.js'?
> BREAKING CHANGE: The request 'process/browser' failed to resolve only because it was resolved as fully specified
> (probably because the origin is strict EcmaScript Module, e. g. a module with javascript mimetype, a '*.mjs' file, or a '*.js' file where the package.json contains '"type": "module"').
> The extension in the request is mandatory for it to be fully specified.
> Add the extension to the request.
> 
> 
> ERROR in ../../node_modules/axios/lib/utils.js
> 
> Cannot read properties of undefined (reading 'module')
> 

I've applied the fix suggested here:  https://github.com/axios/axios/issues/6571 and the project is again compiling properly.

## How to test it
Checkout the project, run `yarn start:tx-builder` and open the tx-builder - the app should build and render with no error.

## Screenshots
<img width="846" height="651" alt="grafik" src="https://github.com/user-attachments/assets/e542f4e1-19a1-46b0-b40d-a797cd7e3fa1" />

