### PR TITLE
fix: build workflow unable to run

### DIFF
--- a/.github/workflows/safe-apps-e2e.yml
+++ b/.github/workflows/safe-apps-e2e.yml
@@ -16,6 +16,9 @@ jobs:
         with:
           access_token: ${{ github.token }}
 
+      - name: Enable Corepack
+        run: corepack enable
+
       - name: Checkout web-core
         uses: actions/checkout@v3
         with:


### PR DESCRIPTION
The e2e test is failing to run as we've specified yarn v4 as the default package, but without doing corepack enable on the CI machine you can't install it. 